### PR TITLE
PR 1: Repo Scaffold & `common/` Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Pytest
+.pytest_cache/
+
+# Editor / OS
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# Environment files
+.env
+*.env
+
+# Distribution
+*.whl
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,5 +1,102 @@
 # Arkadia
 
-Arkadia is a project to monitor home environment conditions like temperature, pressure, humidity, air quality, and ambient sound. The goal is to practice working with sensors and various software architecture patterns. All services and sensors are currently running on a single Raspberry Pi 5.
+Arkadia monitors home environment conditions — temperature, pressure, humidity, CO₂, and ambient sound — using sensors connected to a Raspberry Pi 5.
 
-Arkadia is named after the base camp of the Skaikru people in [the TV show "The 100"](https://en.wikipedia.org/wiki/The_100_(TV_series)).
+Named after the base camp of the Skaikru in [The 100](https://en.wikipedia.org/wiki/The_100_(TV_series)).
+
+---
+
+## Architecture
+
+Sensor services publish JSON payloads to a local Mosquitto MQTT broker. An API service subscribes to all sensor topics, maintains the latest readings in memory, and exposes them over a REST API.
+
+```
+bme280 ─┐
+scd40  ─┼──► Mosquitto :1883 ──► API :8000 ──► External consumers
+audio  ─┘
+```
+
+See [`docs/tech-design.md`](docs/tech-design.md) for the full technical design.
+
+---
+
+## Repository Structure
+
+```
+arkadia/
+├── common/            # Shared library (config, models, MQTT, I2C)
+├── services/
+│   ├── bme280/        # Temperature / humidity / pressure service
+│   ├── scd40/         # CO₂ service
+│   ├── audio/         # Ambient sound service
+│   └── api/           # REST API service
+├── config/
+│   └── global.toml    # Shared broker and logging defaults
+├── mosquitto/
+│   └── mosquitto.conf # Broker configuration
+├── scripts/
+│   ├── setup.sh       # First-time system setup
+│   └── deploy.sh      # Service deployment / restart
+├── tests/             # Unit tests (no hardware required)
+└── pyproject.toml
+```
+
+---
+
+## Quick Start
+
+### Install the shared library
+
+```bash
+pip install -e .
+```
+
+### Run the tests
+
+```bash
+pip install pytest
+pytest
+```
+
+---
+
+## Sensors
+
+| Sensor  | Interface | Topic                         | Measurements                        |
+|---------|-----------|-------------------------------|-------------------------------------|
+| BME280  | I2C       | `home/sensors/climate/bme280` | Temperature, humidity, pressure     |
+| SCD40   | I2C       | `home/sensors/air/scd40`      | CO₂                                 |
+| INMP441 | I2S       | `home/sensors/audio/inmp441`  | Ambient sound (RMS / dBFS)          |
+
+---
+
+## Setup and Deploy
+
+```bash
+sudo bash scripts/setup.sh   # Install system packages and create virtualenvs
+sudo bash scripts/deploy.sh  # Install and start systemd services
+```
+
+---
+
+## Configuration
+
+- Global defaults: `config/global.toml`
+- Per-service overrides: `services/<name>/config.toml`
+- Secrets: `/etc/home-monitor.env` (created by `setup.sh`)
+
+---
+
+## API
+
+Base URL: `http://<pi-hostname>:8000`
+
+| Method | Path                          | Description                     |
+|--------|-------------------------------|---------------------------------|
+| GET    | `/health`                     | Broker connectivity and uptime  |
+| GET    | `/version`                    | Service version and git commit  |
+| GET    | `/sensors`                    | Latest readings from all sensors|
+| GET    | `/sensors/{sensor_id}`        | Latest reading for one sensor   |
+| GET    | `/sensors/{sensor_id}/status` | Staleness metadata              |
+
+All endpoints except `/health` require an `X-API-Key` header.

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,1 @@
+"""Arkadia common shared library."""

--- a/common/config.py
+++ b/common/config.py
@@ -105,13 +105,21 @@ def load_config(
 ) -> dict[str, Any]:
     """Load and merge global config with a service-local config file.
 
-    The global config is loaded first; the local config is then deep-merged
-    on top of it so that local values take precedence.  Returns the raw merged
-    dict; callers are responsible for constructing typed objects from it.
+    The global config is loaded first and validated as a :class:`GlobalConfig`
+    (so invalid ``[broker]`` or ``[logging]`` values in the *global* file are
+    caught immediately).  The local config is then deep-merged on top, with
+    local values taking precedence.
 
-    Raises ``FileNotFoundError`` if *local_path* does not exist.
-    Raises ``ValueError`` (from Pydantic) if validation of shared sections
-    fails.
+    The merged result is returned as a raw ``dict``; callers are responsible
+    for constructing and validating any typed objects they need.  In particular,
+    if the local file overrides ``[broker]`` or ``[logging]`` keys, those
+    overrides are **not** re-validated here.
+
+    Raises:
+        FileNotFoundError: if *local_path* does not exist.
+        pydantic.ValidationError: if the *global* file's ``[broker]`` or
+            ``[logging]`` sections fail validation.
+        tomllib.TOMLDecodeError: if either TOML file has a syntax error.
     """
     local_path = Path(local_path)
     if not local_path.exists():

--- a/common/config.py
+++ b/common/config.py
@@ -1,0 +1,124 @@
+"""TOML configuration loader with global/local merge and typed config objects."""
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Typed config objects
+# ---------------------------------------------------------------------------
+
+
+class BrokerConfig(BaseModel):
+    host: str = "localhost"
+    port: int = 1883
+    keepalive: int = 60
+
+    @field_validator("port")
+    @classmethod
+    def port_in_range(cls, v: int) -> int:
+        if not (1 <= v <= 65535):
+            raise ValueError(f"port must be 1–65535, got {v}")
+        return v
+
+    @field_validator("keepalive")
+    @classmethod
+    def keepalive_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError(f"keepalive must be positive, got {v}")
+        return v
+
+
+class LoggingConfig(BaseModel):
+    level: str = "INFO"
+    format: str = "json"
+
+    @field_validator("level")
+    @classmethod
+    def level_valid(cls, v: str) -> str:
+        valid = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        upper = v.upper()
+        if upper not in valid:
+            raise ValueError(f"level must be one of {valid}, got {v!r}")
+        return upper
+
+    @field_validator("format")
+    @classmethod
+    def format_valid(cls, v: str) -> str:
+        valid = {"json", "text"}
+        lower = v.lower()
+        if lower not in valid:
+            raise ValueError(f"format must be one of {valid}, got {v!r}")
+        return lower
+
+
+class GlobalConfig(BaseModel):
+    broker: BrokerConfig = BrokerConfig()
+    logging: LoggingConfig = LoggingConfig()
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    """Load a TOML file and return its contents as a dict."""
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *override* into *base*, returning a new dict."""
+    result: dict[str, Any] = dict(base)
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def load_global_config(global_path: Path | str | None = None) -> GlobalConfig:
+    """Load and validate the global configuration file.
+
+    If *global_path* is not provided the default ``config/global.toml``
+    relative to the repository root is used.  A missing file is treated as an
+    empty config (all defaults apply).
+    """
+    if global_path is None:
+        # Walk up from this file's location to find the repo root.
+        repo_root = Path(__file__).resolve().parent.parent
+        global_path = repo_root / "config" / "global.toml"
+
+    global_path = Path(global_path)
+    raw: dict[str, Any] = _load_toml(global_path) if global_path.exists() else {}
+    return GlobalConfig.model_validate(raw)
+
+
+def load_config(
+    local_path: Path | str,
+    global_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Load and merge global config with a service-local config file.
+
+    The global config is loaded first; the local config is then deep-merged
+    on top of it so that local values take precedence.  Returns the raw merged
+    dict; callers are responsible for constructing typed objects from it.
+
+    Raises ``FileNotFoundError`` if *local_path* does not exist.
+    Raises ``ValueError`` (from Pydantic) if validation of shared sections
+    fails.
+    """
+    local_path = Path(local_path)
+    if not local_path.exists():
+        raise FileNotFoundError(f"Local config not found: {local_path}")
+
+    global_cfg = load_global_config(global_path)
+    global_raw: dict[str, Any] = global_cfg.model_dump()
+    local_raw: dict[str, Any] = _load_toml(local_path)
+
+    return _deep_merge(global_raw, local_raw)

--- a/common/i2c.py
+++ b/common/i2c.py
@@ -40,14 +40,13 @@ class I2CBase:
         self._bus = bus
         self._address = address
         self._i2c: Any = None
-        self._device: Any = None
 
         self._validate_address(address)
         logger.info(
-            "I2C bus %d address 0x%02X initialised",
-            bus,
+            "I2C address 0x%02X validated (bus %d); hardware init is deferred until first use",
             address,
-            extra={"event": "i2c_init"},
+            bus,
+            extra={"event": "i2c_address_validated"},
         )
 
     # ------------------------------------------------------------------
@@ -103,9 +102,10 @@ class I2CBase:
                 self._i2c.deinit()
             except Exception:
                 logger.exception("Error closing I2C bus", extra={"event": "i2c_close_error"})
+            else:
+                logger.info("I2C bus closed", extra={"event": "i2c_bus_close"})
             finally:
                 self._i2c = None
-                logger.info("I2C bus closed", extra={"event": "i2c_bus_close"})
 
     def __enter__(self) -> "I2CBase":
         return self

--- a/common/i2c.py
+++ b/common/i2c.py
@@ -25,7 +25,7 @@ class I2CBase:
     hardware-specific dependencies installed.
     """
 
-    def __init__(self, bus: int = 1, address: int = 0x00) -> None:
+    def __init__(self, bus: int = 1, *, address: int) -> None:
         """Initialise the I2C bus and verify the device is present.
 
         Parameters
@@ -33,7 +33,9 @@ class I2CBase:
         bus:
             I2C bus number (e.g. ``1`` for ``/dev/i2c-1``).
         address:
-            7-bit I2C device address.
+            7-bit I2C device address (keyword-only, required).  There is no
+            sensible generic default — callers must always supply the device's
+            actual address.  Valid range: ``0x08``–``0x77``.
         """
         self._bus = bus
         self._address = address

--- a/common/i2c.py
+++ b/common/i2c.py
@@ -1,0 +1,112 @@
+"""I2C base class with bus initialisation, address config, and error handling."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class I2CError(OSError):
+    """Raised when an I2C operation fails."""
+
+
+class I2CBase:
+    """Base class for I2C sensor drivers.
+
+    Subclasses should override :meth:`read` to return a dict of measurement
+    values.  The constructor performs bus initialisation and validates the
+    address; failures raise :class:`I2CError` immediately so that systemd can
+    restart the service.
+
+    This class does **not** import ``board`` or ``busio`` at module level so
+    that the shared library can be imported in test environments without
+    hardware-specific dependencies installed.
+    """
+
+    def __init__(self, bus: int = 1, address: int = 0x00) -> None:
+        """Initialise the I2C bus and verify the device is present.
+
+        Parameters
+        ----------
+        bus:
+            I2C bus number (e.g. ``1`` for ``/dev/i2c-1``).
+        address:
+            7-bit I2C device address.
+        """
+        self._bus = bus
+        self._address = address
+        self._i2c: Any = None
+        self._device: Any = None
+
+        self._validate_address(address)
+        logger.info(
+            "I2C bus %d address 0x%02X initialised",
+            bus,
+            address,
+            extra={"event": "i2c_init"},
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_address(address: int) -> None:
+        """Raise :class:`I2CError` if *address* is not a valid 7-bit address."""
+        if not (0x08 <= address <= 0x77):
+            raise I2CError(
+                f"I2C address 0x{address:02X} is outside the valid range "
+                f"0x08–0x77 (reserved addresses excluded)"
+            )
+
+    def _init_hardware(self) -> None:
+        """Initialise the CircuitPython I2C bus.
+
+        This method is separated from ``__init__`` so that it can be called
+        lazily (or mocked in tests).  It imports ``board`` and ``busio`` only
+        when hardware access is actually needed.
+        """
+        try:
+            import board  # type: ignore[import-untyped]
+            import busio  # type: ignore[import-untyped]
+
+            self._i2c = busio.I2C(board.SCL, board.SDA)
+            logger.info(
+                "Hardware I2C bus opened",
+                extra={"event": "i2c_bus_open"},
+            )
+        except Exception as exc:
+            raise I2CError(f"Failed to open I2C bus {self._bus}: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def read(self) -> dict[str, float]:
+        """Read a single sample from the sensor.
+
+        Subclasses must override this method.  Returns a dict of measurement
+        names to float values.
+
+        Raises :class:`I2CError` on hardware failure.
+        """
+        raise NotImplementedError("Subclasses must implement read()")
+
+    def close(self) -> None:
+        """Release I2C resources."""
+        if self._i2c is not None:
+            try:
+                self._i2c.deinit()
+            except Exception:
+                logger.exception("Error closing I2C bus", extra={"event": "i2c_close_error"})
+            finally:
+                self._i2c = None
+                logger.info("I2C bus closed", extra={"event": "i2c_bus_close"})
+
+    def __enter__(self) -> "I2CBase":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()

--- a/common/models.py
+++ b/common/models.py
@@ -1,0 +1,138 @@
+"""Pydantic models for all sensor payloads and the standard envelope."""
+
+from datetime import datetime, timezone
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+# ---------------------------------------------------------------------------
+# Shared envelope sub-models
+# ---------------------------------------------------------------------------
+
+
+class Meta(BaseModel):
+    """Aggregation metadata included in every payload."""
+
+    sample_count: int = Field(..., ge=1, description="Number of samples taken")
+    aggregation: str = Field(..., description="Aggregation method, e.g. 'median' or 'rms'")
+
+
+class Diagnostics(BaseModel):
+    """Optional service diagnostics block."""
+
+    uptime_seconds: float = Field(..., ge=0)
+    read_failures: int = Field(0, ge=0)
+
+
+# ---------------------------------------------------------------------------
+# Per-sensor readings models
+# ---------------------------------------------------------------------------
+
+
+class BME280Readings(BaseModel):
+    """Temperature, humidity, and pressure from the BME280."""
+
+    temperature_c: float = Field(..., description="Temperature in degrees Celsius")
+    humidity_pct: float = Field(..., ge=0, le=100, description="Relative humidity in percent")
+    pressure_hpa: float = Field(..., gt=0, description="Atmospheric pressure in hPa")
+
+
+class SCD40Readings(BaseModel):
+    """CO₂ concentration from the SCD40."""
+
+    co2_ppm: float = Field(..., ge=0, description="CO₂ concentration in parts per million")
+    temperature_c: float | None = Field(None, description="Temperature in degrees Celsius (if available)")
+    humidity_pct: float | None = Field(None, ge=0, le=100, description="Relative humidity in percent (if available)")
+
+
+class AudioReadings(BaseModel):
+    """Ambient sound level from the INMP441 microphone."""
+
+    rms_amplitude: float = Field(..., ge=0, description="RMS amplitude of the sample window")
+    db_level: float = Field(..., description="Sound pressure level in dBFS")
+
+
+# ---------------------------------------------------------------------------
+# Standard envelope
+# ---------------------------------------------------------------------------
+
+
+class SensorPayload(BaseModel):
+    """Standard envelope wrapping any sensor's readings."""
+
+    schema_version: Literal[1] = 1
+    sensor_id: str = Field(..., min_length=1)
+    timestamp: datetime = Field(..., description="UTC ISO 8601 timestamp of the reading")
+    readings: BME280Readings | SCD40Readings | AudioReadings
+    meta: Meta
+    diagnostics: Diagnostics | None = None
+
+    @field_validator("timestamp")
+    @classmethod
+    def ensure_utc(cls, v: datetime) -> datetime:
+        """Normalise naive datetimes to UTC; reject non-UTC aware datetimes."""
+        if v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v.astimezone(timezone.utc)
+
+    model_config = {}
+
+
+# ---------------------------------------------------------------------------
+# Sensor-specific typed payloads (sensor_id is fixed per type)
+# ---------------------------------------------------------------------------
+
+
+class BME280Payload(BaseModel):
+    """Fully-typed payload for the BME280 climate sensor."""
+
+    schema_version: Literal[1] = 1
+    sensor_id: str = Field("bme280", pattern=r"^bme280$")
+    timestamp: datetime
+    readings: BME280Readings
+    meta: Meta
+    diagnostics: Diagnostics | None = None
+
+    @field_validator("timestamp")
+    @classmethod
+    def ensure_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v.astimezone(timezone.utc)
+
+
+class SCD40Payload(BaseModel):
+    """Fully-typed payload for the SCD40 CO₂ sensor."""
+
+    schema_version: Literal[1] = 1
+    sensor_id: str = Field("scd40", pattern=r"^scd40$")
+    timestamp: datetime
+    readings: SCD40Readings
+    meta: Meta
+    diagnostics: Diagnostics | None = None
+
+    @field_validator("timestamp")
+    @classmethod
+    def ensure_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v.astimezone(timezone.utc)
+
+
+class AudioPayload(BaseModel):
+    """Fully-typed payload for the INMP441 audio sensor."""
+
+    schema_version: Literal[1] = 1
+    sensor_id: str = Field("inmp441", pattern=r"^inmp441$")
+    timestamp: datetime
+    readings: AudioReadings
+    meta: Meta
+    diagnostics: Diagnostics | None = None
+
+    @field_validator("timestamp")
+    @classmethod
+    def ensure_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v.astimezone(timezone.utc)

--- a/common/models.py
+++ b/common/models.py
@@ -1,9 +1,42 @@
 """Pydantic models for all sensor payloads and the standard envelope."""
 
 from datetime import datetime, timezone
-from typing import Annotated, Any, Literal
+from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator
+
+
+# ---------------------------------------------------------------------------
+# UTC timestamp helper
+# ---------------------------------------------------------------------------
+
+
+def _normalise_to_utc(v: datetime) -> datetime:
+    """Normalise *v* to an aware UTC datetime.
+
+    - Naive datetimes are assumed to already be in UTC and have ``tzinfo``
+      attached without conversion.
+    - Aware datetimes are converted to UTC regardless of their original zone.
+    """
+    if v.tzinfo is None:
+        return v.replace(tzinfo=timezone.utc)
+    return v.astimezone(timezone.utc)
+
+
+class _UTCTimestampMixin(BaseModel):
+    """Mixin that applies :func:`_normalise_to_utc` to the ``timestamp`` field.
+
+    Inherit from this instead of repeating the ``ensure_utc`` validator in
+    every payload class.  Pydantic v2 picks up validators defined on any class
+    in the MRO, so the validator is active in all subclasses automatically.
+    """
+
+    timestamp: datetime
+
+    @field_validator("timestamp")
+    @classmethod
+    def ensure_utc(cls, v: datetime) -> datetime:
+        return _normalise_to_utc(v)
 
 
 # ---------------------------------------------------------------------------
@@ -58,7 +91,7 @@ class AudioReadings(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class SensorPayload(BaseModel):
+class SensorPayload(_UTCTimestampMixin):
     """Standard envelope wrapping any sensor's readings."""
 
     schema_version: Literal[1] = 1
@@ -68,23 +101,13 @@ class SensorPayload(BaseModel):
     meta: Meta
     diagnostics: Diagnostics | None = None
 
-    @field_validator("timestamp")
-    @classmethod
-    def ensure_utc(cls, v: datetime) -> datetime:
-        """Normalise naive datetimes to UTC; reject non-UTC aware datetimes."""
-        if v.tzinfo is None:
-            return v.replace(tzinfo=timezone.utc)
-        return v.astimezone(timezone.utc)
-
-    model_config = {}
-
 
 # ---------------------------------------------------------------------------
 # Sensor-specific typed payloads (sensor_id is fixed per type)
 # ---------------------------------------------------------------------------
 
 
-class BME280Payload(BaseModel):
+class BME280Payload(_UTCTimestampMixin):
     """Fully-typed payload for the BME280 climate sensor."""
 
     schema_version: Literal[1] = 1
@@ -94,15 +117,8 @@ class BME280Payload(BaseModel):
     meta: Meta
     diagnostics: Diagnostics | None = None
 
-    @field_validator("timestamp")
-    @classmethod
-    def ensure_utc(cls, v: datetime) -> datetime:
-        if v.tzinfo is None:
-            return v.replace(tzinfo=timezone.utc)
-        return v.astimezone(timezone.utc)
 
-
-class SCD40Payload(BaseModel):
+class SCD40Payload(_UTCTimestampMixin):
     """Fully-typed payload for the SCD40 CO₂ sensor."""
 
     schema_version: Literal[1] = 1
@@ -112,15 +128,8 @@ class SCD40Payload(BaseModel):
     meta: Meta
     diagnostics: Diagnostics | None = None
 
-    @field_validator("timestamp")
-    @classmethod
-    def ensure_utc(cls, v: datetime) -> datetime:
-        if v.tzinfo is None:
-            return v.replace(tzinfo=timezone.utc)
-        return v.astimezone(timezone.utc)
 
-
-class AudioPayload(BaseModel):
+class AudioPayload(_UTCTimestampMixin):
     """Fully-typed payload for the INMP441 audio sensor."""
 
     schema_version: Literal[1] = 1
@@ -129,10 +138,3 @@ class AudioPayload(BaseModel):
     readings: AudioReadings
     meta: Meta
     diagnostics: Diagnostics | None = None
-
-    @field_validator("timestamp")
-    @classmethod
-    def ensure_utc(cls, v: datetime) -> datetime:
-        if v.tzinfo is None:
-            return v.replace(tzinfo=timezone.utc)
-        return v.astimezone(timezone.utc)

--- a/common/mqtt.py
+++ b/common/mqtt.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
@@ -187,7 +186,14 @@ class MQTTClient:
     # ------------------------------------------------------------------
 
     def connect(self) -> None:
-        """Connect to the broker (blocking until the connection is accepted)."""
+        """Initiate a connection to the broker.
+
+        Opens the TCP socket and sends the MQTT ``CONNECT`` packet, then
+        returns immediately.  The ``CONNACK`` response is processed
+        asynchronously; ``is_connected`` will be ``False`` until
+        ``loop_start()`` is running and the broker acknowledges the
+        connection.
+        """
         logger.info(
             "Connecting to %s:%s",
             self._broker_host,
@@ -225,8 +231,12 @@ class MQTTClient:
     ) -> None:
         """Publish a message to *topic*.
 
-        Raises ``RuntimeError`` if the client is not connected.
+        Raises ``RuntimeError`` if the client is not currently connected to
+        the broker.  Callers should call ``connect()`` and ``loop_start()``
+        before publishing.
         """
+        if not self._connected:
+            raise RuntimeError("Cannot publish: not connected to broker")
         result = self._client.publish(topic, payload=payload, qos=qos, retain=retain)
         result.wait_for_publish(timeout=5)
         logger.debug(

--- a/common/mqtt.py
+++ b/common/mqtt.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 import paho.mqtt.client as mqtt
@@ -19,11 +20,24 @@ logger = logging.getLogger(__name__)
 
 
 class JsonFormatter(logging.Formatter):
-    """Emit log records as single-line JSON objects."""
+    """Emit log records as single-line JSON objects with UTC timestamps."""
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        """Return the log record creation time as a UTC ISO 8601 string.
+
+        Overrides the default implementation, which uses ``time.localtime``
+        (the process's local timezone).  The ``Z`` suffix in ISO 8601 denotes
+        UTC; using localtime would produce a misleading timestamp on any host
+        not configured to UTC.
+        """
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        if datefmt:
+            return dt.strftime(datefmt)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def format(self, record: logging.LogRecord) -> str:
         payload: dict[str, Any] = {
-            "timestamp": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%SZ"),
+            "timestamp": self.formatTime(record),
             "level": record.levelname,
             "service": record.name,
             "event": getattr(record, "event", "log"),
@@ -97,7 +111,7 @@ class MQTTClient:
         self._client.on_disconnect = self._on_disconnect
         self._client.on_message = self._on_message
 
-        self._message_callbacks: dict[str, Callable[[str, bytes], None]] = {}
+        self._message_callbacks: dict[str, tuple[Callable[[str, bytes], None], int]] = {}
 
         if lwt:
             self._client.will_set(
@@ -128,8 +142,8 @@ class MQTTClient:
             return
         self._connected = True
         logger.info("Connected to broker", extra={"event": "mqtt_connected"})
-        for topic in self._message_callbacks:
-            self._client.subscribe(topic)
+        for topic, (_, qos) in self._message_callbacks.items():
+            self._client.subscribe(topic, qos=qos)
 
     def _on_disconnect(
         self,
@@ -157,7 +171,7 @@ class MQTTClient:
         message: mqtt.MQTTMessage,
     ) -> None:
         topic = message.topic
-        for pattern, cb in self._message_callbacks.items():
+        for pattern, (cb, _) in self._message_callbacks.items():
             if mqtt.topic_matches_sub(pattern, topic):
                 try:
                     cb(topic, message.payload)
@@ -232,7 +246,7 @@ class MQTTClient:
         The callback signature is ``(topic: str, payload: bytes) -> None``.
         Subscriptions made before ``connect()`` are re-applied on reconnect.
         """
-        self._message_callbacks[topic] = callback
+        self._message_callbacks[topic] = (callback, qos)
         if self._connected:
             self._client.subscribe(topic, qos=qos)
         logger.debug("Subscribed to %s", topic, extra={"event": "mqtt_subscribe"})

--- a/common/mqtt.py
+++ b/common/mqtt.py
@@ -1,0 +1,243 @@
+"""paho-mqtt wrapper with auto-reconnect and structured logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+import paho.mqtt.client as mqtt
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Structured JSON logging formatter
+# ---------------------------------------------------------------------------
+
+
+class JsonFormatter(logging.Formatter):
+    """Emit log records as single-line JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%SZ"),
+            "level": record.levelname,
+            "service": record.name,
+            "event": getattr(record, "event", "log"),
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload)
+
+
+def configure_logging(level: str = "INFO", fmt: str = "json") -> None:
+    """Configure the root logger with structured JSON or plain-text output."""
+    handler = logging.StreamHandler()
+    if fmt == "json":
+        handler.setFormatter(JsonFormatter())
+    logging.basicConfig(level=level.upper(), handlers=[handler])
+
+
+# ---------------------------------------------------------------------------
+# LWT configuration
+# ---------------------------------------------------------------------------
+
+
+class LWTConfig:
+    """Last Will and Testament configuration."""
+
+    def __init__(self, topic: str, payload: str, qos: int = 1, retain: bool = True) -> None:
+        self.topic = topic
+        self.payload = payload
+        self.qos = qos
+        self.retain = retain
+
+
+# ---------------------------------------------------------------------------
+# MQTTClient
+# ---------------------------------------------------------------------------
+
+
+class MQTTClient:
+    """Thin paho-mqtt wrapper with auto-reconnect and structured logging.
+
+    Usage::
+
+        client = MQTTClient(client_id="my-service", broker_host="localhost")
+        client.connect()
+        client.loop_start()
+        client.publish("home/sensors/climate/bme280", payload_json, qos=1, retain=True)
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        broker_host: str = "localhost",
+        broker_port: int = 1883,
+        keepalive: int = 60,
+        lwt: LWTConfig | None = None,
+        reconnect_delay: float = 5.0,
+    ) -> None:
+        self._broker_host = broker_host
+        self._broker_port = broker_port
+        self._keepalive = keepalive
+        self._lwt = lwt
+        self._reconnect_delay = reconnect_delay
+        self._connected = False
+
+        self._client = mqtt.Client(
+            client_id=client_id,
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+        )
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
+        self._client.on_message = self._on_message
+
+        self._message_callbacks: dict[str, Callable[[str, bytes], None]] = {}
+
+        if lwt:
+            self._client.will_set(
+                lwt.topic,
+                payload=lwt.payload,
+                qos=lwt.qos,
+                retain=lwt.retain,
+            )
+
+    # ------------------------------------------------------------------
+    # paho callbacks
+    # ------------------------------------------------------------------
+
+    def _on_connect(
+        self,
+        client: mqtt.Client,
+        userdata: Any,
+        connect_flags: mqtt.ConnectFlags,
+        reason_code: mqtt.ReasonCode,
+        properties: Any,
+    ) -> None:
+        if reason_code.is_failure:
+            logger.error(
+                "MQTT connection failed: %s",
+                reason_code,
+                extra={"event": "mqtt_connect_failed"},
+            )
+            return
+        self._connected = True
+        logger.info("Connected to broker", extra={"event": "mqtt_connected"})
+        for topic in self._message_callbacks:
+            self._client.subscribe(topic)
+
+    def _on_disconnect(
+        self,
+        client: mqtt.Client,
+        userdata: Any,
+        disconnect_flags: mqtt.DisconnectFlags,
+        reason_code: mqtt.ReasonCode,
+        properties: Any,
+    ) -> None:
+        self._connected = False
+        if reason_code.is_failure:
+            logger.warning(
+                "Unexpected disconnect (rc=%s); will reconnect in %ss",
+                reason_code,
+                self._reconnect_delay,
+                extra={"event": "mqtt_disconnected"},
+            )
+        else:
+            logger.info("Disconnected from broker", extra={"event": "mqtt_disconnected"})
+
+    def _on_message(
+        self,
+        client: mqtt.Client,
+        userdata: Any,
+        message: mqtt.MQTTMessage,
+    ) -> None:
+        topic = message.topic
+        for pattern, cb in self._message_callbacks.items():
+            if mqtt.topic_matches_sub(pattern, topic):
+                try:
+                    cb(topic, message.payload)
+                except Exception:
+                    logger.exception(
+                        "Error in message callback for topic %s",
+                        topic,
+                        extra={"event": "mqtt_callback_error"},
+                    )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def connect(self) -> None:
+        """Connect to the broker (blocking until the connection is accepted)."""
+        logger.info(
+            "Connecting to %s:%s",
+            self._broker_host,
+            self._broker_port,
+            extra={"event": "mqtt_connecting"},
+        )
+        self._client.reconnect_delay_set(
+            min_delay=1,
+            max_delay=int(self._reconnect_delay),
+        )
+        self._client.connect(
+            self._broker_host,
+            self._broker_port,
+            self._keepalive,
+        )
+
+    def loop_start(self) -> None:
+        """Start the paho network loop in a background thread."""
+        self._client.loop_start()
+
+    def loop_stop(self) -> None:
+        """Stop the background network loop."""
+        self._client.loop_stop()
+
+    def disconnect(self) -> None:
+        """Gracefully disconnect from the broker."""
+        self._client.disconnect()
+
+    def publish(
+        self,
+        topic: str,
+        payload: str | bytes,
+        qos: int = 1,
+        retain: bool = False,
+    ) -> None:
+        """Publish a message to *topic*.
+
+        Raises ``RuntimeError`` if the client is not connected.
+        """
+        result = self._client.publish(topic, payload=payload, qos=qos, retain=retain)
+        result.wait_for_publish(timeout=5)
+        logger.debug(
+            "Published to %s",
+            topic,
+            extra={"event": "mqtt_publish"},
+        )
+
+    def subscribe(
+        self,
+        topic: str,
+        callback: Callable[[str, bytes], None],
+        qos: int = 1,
+    ) -> None:
+        """Subscribe to *topic* and register *callback* for matching messages.
+
+        The callback signature is ``(topic: str, payload: bytes) -> None``.
+        Subscriptions made before ``connect()`` are re-applied on reconnect.
+        """
+        self._message_callbacks[topic] = callback
+        if self._connected:
+            self._client.subscribe(topic, qos=qos)
+        logger.debug("Subscribed to %s", topic, extra={"event": "mqtt_subscribe"})
+
+    @property
+    def is_connected(self) -> bool:
+        """Return ``True`` if the client is currently connected to the broker."""
+        return self._connected

--- a/config/global.toml
+++ b/config/global.toml
@@ -1,0 +1,8 @@
+[broker]
+host = "localhost"
+port = 1883
+keepalive = 60
+
+[logging]
+level = "INFO"
+format = "json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "common"
+version = "0.1.0"
+description = "Shared library for the Arkadia home environment monitor"
+requires-python = ">=3.11"
+dependencies = [
+    "paho-mqtt>=2.0",
+    "pydantic>=2.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["common*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,216 @@
+"""Unit tests for common/config.py — no hardware required."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from common.config import (
+    BrokerConfig,
+    GlobalConfig,
+    LoggingConfig,
+    _deep_merge,
+    load_config,
+    load_global_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# BrokerConfig validation
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerConfig:
+    def test_defaults(self):
+        cfg = BrokerConfig()
+        assert cfg.host == "localhost"
+        assert cfg.port == 1883
+        assert cfg.keepalive == 60
+
+    def test_custom_values(self):
+        cfg = BrokerConfig(host="192.168.1.1", port=8883, keepalive=30)
+        assert cfg.host == "192.168.1.1"
+        assert cfg.port == 8883
+        assert cfg.keepalive == 30
+
+    def test_port_too_low(self):
+        with pytest.raises(ValueError, match="port must be"):
+            BrokerConfig(port=0)
+
+    def test_port_too_high(self):
+        with pytest.raises(ValueError, match="port must be"):
+            BrokerConfig(port=70000)
+
+    def test_keepalive_zero(self):
+        with pytest.raises(ValueError, match="keepalive must be positive"):
+            BrokerConfig(keepalive=0)
+
+    def test_keepalive_negative(self):
+        with pytest.raises(ValueError, match="keepalive must be positive"):
+            BrokerConfig(keepalive=-1)
+
+
+# ---------------------------------------------------------------------------
+# LoggingConfig validation
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingConfig:
+    def test_defaults(self):
+        cfg = LoggingConfig()
+        assert cfg.level == "INFO"
+        assert cfg.format == "json"
+
+    def test_level_normalised_to_upper(self):
+        cfg = LoggingConfig(level="debug")
+        assert cfg.level == "DEBUG"
+
+    def test_format_normalised_to_lower(self):
+        cfg = LoggingConfig(format="JSON")
+        assert cfg.format == "json"
+
+    def test_invalid_level(self):
+        with pytest.raises(ValueError, match="level must be one of"):
+            LoggingConfig(level="VERBOSE")
+
+    def test_invalid_format(self):
+        with pytest.raises(ValueError, match="format must be one of"):
+            LoggingConfig(format="yaml")
+
+
+# ---------------------------------------------------------------------------
+# GlobalConfig
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalConfig:
+    def test_defaults(self):
+        cfg = GlobalConfig()
+        assert cfg.broker.host == "localhost"
+        assert cfg.logging.level == "INFO"
+
+    def test_partial_override(self):
+        cfg = GlobalConfig(broker={"host": "mqtt.local", "port": 1883, "keepalive": 60})
+        assert cfg.broker.host == "mqtt.local"
+
+
+# ---------------------------------------------------------------------------
+# _deep_merge
+# ---------------------------------------------------------------------------
+
+
+class TestDeepMerge:
+    def test_simple_override(self):
+        base = {"a": 1, "b": 2}
+        override = {"b": 99, "c": 3}
+        result = _deep_merge(base, override)
+        assert result == {"a": 1, "b": 99, "c": 3}
+
+    def test_nested_merge(self):
+        base = {"broker": {"host": "localhost", "port": 1883}}
+        override = {"broker": {"port": 8883}}
+        result = _deep_merge(base, override)
+        assert result == {"broker": {"host": "localhost", "port": 8883}}
+
+    def test_base_not_mutated(self):
+        base = {"a": {"x": 1}}
+        override = {"a": {"x": 2}}
+        _deep_merge(base, override)
+        assert base["a"]["x"] == 1  # base is unchanged
+
+    def test_override_adds_new_key(self):
+        base = {"a": 1}
+        override = {"b": 2}
+        result = _deep_merge(base, override)
+        assert result == {"a": 1, "b": 2}
+
+
+# ---------------------------------------------------------------------------
+# load_global_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadGlobalConfig:
+    def test_loads_real_global_toml(self):
+        """Load the actual config/global.toml in the repo."""
+        repo_root = Path(__file__).resolve().parent.parent
+        cfg = load_global_config(repo_root / "config" / "global.toml")
+        assert cfg.broker.host == "localhost"
+        assert cfg.broker.port == 1883
+        assert cfg.logging.format == "json"
+
+    def test_missing_file_returns_defaults(self, tmp_path):
+        missing = tmp_path / "nonexistent.toml"
+        cfg = load_global_config(missing)
+        assert cfg == GlobalConfig()
+
+    def test_partial_global_file(self, tmp_path):
+        toml_file = tmp_path / "global.toml"
+        toml_file.write_text(
+            textwrap.dedent("""\
+                [broker]
+                host = "mqtt.example.com"
+            """)
+        )
+        cfg = load_global_config(toml_file)
+        assert cfg.broker.host == "mqtt.example.com"
+        assert cfg.broker.port == 1883  # default
+
+    def test_invalid_global_file(self, tmp_path):
+        toml_file = tmp_path / "global.toml"
+        toml_file.write_text(
+            textwrap.dedent("""\
+                [broker]
+                port = 99999
+            """)
+        )
+        with pytest.raises(ValueError):
+            load_global_config(toml_file)
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_local_overrides_global(self, tmp_path):
+        global_file = tmp_path / "global.toml"
+        global_file.write_text(
+            textwrap.dedent("""\
+                [broker]
+                host = "localhost"
+                port = 1883
+                keepalive = 60
+
+                [logging]
+                level = "INFO"
+                format = "json"
+            """)
+        )
+        local_file = tmp_path / "local.toml"
+        local_file.write_text(
+            textwrap.dedent("""\
+                [broker]
+                port = 8883
+
+                [sensor]
+                interval_seconds = 30
+            """)
+        )
+        merged = load_config(local_file, global_path=global_file)
+        assert merged["broker"]["host"] == "localhost"  # from global
+        assert merged["broker"]["port"] == 8883          # overridden by local
+        assert merged["sensor"]["interval_seconds"] == 30  # local-only key
+
+    def test_missing_local_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_config(tmp_path / "missing.toml")
+
+    def test_no_global_path_uses_repo_default(self, tmp_path):
+        """When global_path is omitted the repo's global.toml should be used."""
+        local_file = tmp_path / "service.toml"
+        local_file.write_text("[mqtt]\ntopic = \"home/sensors/test\"\n")
+        merged = load_config(local_file)
+        assert merged["broker"]["host"] == "localhost"
+        assert merged["mqtt"]["topic"] == "home/sensors/test"

--- a/tests/test_i2c.py
+++ b/tests/test_i2c.py
@@ -1,0 +1,74 @@
+"""Unit tests for common/i2c.py — no hardware required."""
+
+import pytest
+
+from common.i2c import I2CBase, I2CError
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: address must be keyword-only and required (no default=0x00)
+# ---------------------------------------------------------------------------
+
+
+class TestI2CBaseAddressRequirement:
+    def test_address_is_required(self):
+        """I2CBase() without an address must raise TypeError, not I2CError."""
+        with pytest.raises(TypeError):
+            I2CBase()  # address not supplied
+
+    def test_address_keyword_only(self):
+        """address cannot be passed positionally."""
+        with pytest.raises(TypeError):
+            I2CBase(1, 0x76)  # second positional arg — keyword-only since Bug 2 fix
+
+    def test_valid_address_accepted(self):
+        base = I2CBase(address=0x76)
+        assert base._address == 0x76
+
+    def test_valid_address_with_bus(self):
+        base = I2CBase(bus=1, address=0x76)
+        assert base._bus == 1
+        assert base._address == 0x76
+
+    def test_default_bus_is_one(self):
+        base = I2CBase(address=0x76)
+        assert base._bus == 1
+
+
+class TestI2CBaseAddressValidation:
+    def test_address_too_low(self):
+        with pytest.raises(I2CError, match="outside the valid range"):
+            I2CBase(address=0x07)
+
+    def test_address_zero(self):
+        """0x00 (the former misleading default) must be rejected."""
+        with pytest.raises(I2CError, match="outside the valid range"):
+            I2CBase(address=0x00)
+
+    def test_address_reserved_high(self):
+        with pytest.raises(I2CError, match="outside the valid range"):
+            I2CBase(address=0x78)
+
+    def test_address_lower_boundary(self):
+        base = I2CBase(address=0x08)
+        assert base._address == 0x08
+
+    def test_address_upper_boundary(self):
+        base = I2CBase(address=0x77)
+        assert base._address == 0x77
+
+
+class TestI2CBaseReadNotImplemented:
+    def test_read_raises(self):
+        base = I2CBase(address=0x76)
+        with pytest.raises(NotImplementedError):
+            base.read()
+
+
+class TestI2CBaseContextManager:
+    def test_context_manager_no_hardware(self):
+        """Context manager must work even without hardware (no _i2c to deinit)."""
+        with I2CBase(address=0x76) as base:
+            assert base._address == 0x76
+        # close() should be a no-op when _i2c is None
+        assert base._i2c is None

--- a/tests/test_i2c.py
+++ b/tests/test_i2c.py
@@ -72,3 +72,15 @@ class TestI2CBaseContextManager:
             assert base._address == 0x76
         # close() should be a no-op when _i2c is None
         assert base._i2c is None
+
+
+class TestI2CBaseAttributes:
+    def test_no_device_attribute(self):
+        """_device was removed as unused dead code; it must not exist on base."""
+        base = I2CBase(address=0x76)
+        assert not hasattr(base, "_device"), "_device is dead code and was removed"
+
+    def test_i2c_starts_as_none(self):
+        """_i2c must be None until _init_hardware() is called."""
+        base = I2CBase(address=0x76)
+        assert base._i2c is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,261 @@
+"""Unit tests for common/models.py — no hardware required."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from common.models import (
+    AudioPayload,
+    AudioReadings,
+    BME280Payload,
+    BME280Readings,
+    Diagnostics,
+    Meta,
+    SCD40Payload,
+    SCD40Readings,
+    SensorPayload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Meta
+# ---------------------------------------------------------------------------
+
+
+class TestMeta:
+    def test_valid(self):
+        m = Meta(sample_count=5, aggregation="median")
+        assert m.sample_count == 5
+        assert m.aggregation == "median"
+
+    def test_zero_sample_count(self):
+        with pytest.raises(ValidationError):
+            Meta(sample_count=0, aggregation="median")
+
+    def test_negative_sample_count(self):
+        with pytest.raises(ValidationError):
+            Meta(sample_count=-1, aggregation="median")
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnostics:
+    def test_valid(self):
+        d = Diagnostics(uptime_seconds=1234.5, read_failures=0)
+        assert d.uptime_seconds == 1234.5
+        assert d.read_failures == 0
+
+    def test_negative_uptime(self):
+        with pytest.raises(ValidationError):
+            Diagnostics(uptime_seconds=-1)
+
+    def test_negative_read_failures(self):
+        with pytest.raises(ValidationError):
+            Diagnostics(uptime_seconds=0, read_failures=-1)
+
+
+# ---------------------------------------------------------------------------
+# BME280Readings
+# ---------------------------------------------------------------------------
+
+
+class TestBME280Readings:
+    def test_valid(self):
+        r = BME280Readings(temperature_c=21.4, humidity_pct=55.2, pressure_hpa=1013.25)
+        assert r.temperature_c == 21.4
+
+    def test_humidity_out_of_range_high(self):
+        with pytest.raises(ValidationError):
+            BME280Readings(temperature_c=20, humidity_pct=101, pressure_hpa=1000)
+
+    def test_humidity_out_of_range_low(self):
+        with pytest.raises(ValidationError):
+            BME280Readings(temperature_c=20, humidity_pct=-1, pressure_hpa=1000)
+
+    def test_pressure_zero(self):
+        with pytest.raises(ValidationError):
+            BME280Readings(temperature_c=20, humidity_pct=50, pressure_hpa=0)
+
+
+# ---------------------------------------------------------------------------
+# SCD40Readings
+# ---------------------------------------------------------------------------
+
+
+class TestSCD40Readings:
+    def test_valid_minimal(self):
+        r = SCD40Readings(co2_ppm=412.5)
+        assert r.co2_ppm == 412.5
+        assert r.temperature_c is None
+        assert r.humidity_pct is None
+
+    def test_valid_full(self):
+        r = SCD40Readings(co2_ppm=412.5, temperature_c=22.1, humidity_pct=48.3)
+        assert r.temperature_c == 22.1
+
+    def test_negative_co2(self):
+        with pytest.raises(ValidationError):
+            SCD40Readings(co2_ppm=-1)
+
+
+# ---------------------------------------------------------------------------
+# AudioReadings
+# ---------------------------------------------------------------------------
+
+
+class TestAudioReadings:
+    def test_valid(self):
+        r = AudioReadings(rms_amplitude=0.05, db_level=-26.0)
+        assert r.rms_amplitude == 0.05
+
+    def test_negative_rms(self):
+        with pytest.raises(ValidationError):
+            AudioReadings(rms_amplitude=-0.1, db_level=-26.0)
+
+
+# ---------------------------------------------------------------------------
+# SensorPayload (generic envelope)
+# ---------------------------------------------------------------------------
+
+NOW_UTC = datetime(2026, 5, 8, 14, 23, 1, tzinfo=timezone.utc)
+
+
+class TestSensorPayload:
+    def _bme280_payload_data(self):
+        return {
+            "schema_version": 1,
+            "sensor_id": "bme280",
+            "timestamp": NOW_UTC,
+            "readings": BME280Readings(temperature_c=21.4, humidity_pct=55.2, pressure_hpa=1013.25),
+            "meta": Meta(sample_count=5, aggregation="median"),
+        }
+
+    def test_valid_without_diagnostics(self):
+        p = SensorPayload(**self._bme280_payload_data())
+        assert p.schema_version == 1
+        assert p.sensor_id == "bme280"
+        assert p.diagnostics is None
+
+    def test_valid_with_diagnostics(self):
+        data = self._bme280_payload_data()
+        data["diagnostics"] = Diagnostics(uptime_seconds=3600, read_failures=2)
+        p = SensorPayload(**data)
+        assert p.diagnostics.read_failures == 2
+
+    def test_naive_timestamp_gets_utc(self):
+        data = self._bme280_payload_data()
+        data["timestamp"] = datetime(2026, 5, 8, 14, 23, 1)  # naive
+        p = SensorPayload(**data)
+        assert p.timestamp.tzinfo == timezone.utc
+
+    def test_wrong_schema_version(self):
+        data = self._bme280_payload_data()
+        data["schema_version"] = 2  # only 1 is valid
+        with pytest.raises(ValidationError):
+            SensorPayload(**data)
+
+    def test_empty_sensor_id(self):
+        data = self._bme280_payload_data()
+        data["sensor_id"] = ""
+        with pytest.raises(ValidationError):
+            SensorPayload(**data)
+
+
+# ---------------------------------------------------------------------------
+# Sensor-specific typed payloads
+# ---------------------------------------------------------------------------
+
+
+class TestBME280Payload:
+    def test_valid(self):
+        p = BME280Payload(
+            sensor_id="bme280",
+            timestamp=NOW_UTC,
+            readings=BME280Readings(temperature_c=21.4, humidity_pct=55.2, pressure_hpa=1013.25),
+            meta=Meta(sample_count=5, aggregation="median"),
+        )
+        assert p.sensor_id == "bme280"
+
+    def test_wrong_sensor_id(self):
+        with pytest.raises(ValidationError):
+            BME280Payload(
+                sensor_id="scd40",
+                timestamp=NOW_UTC,
+                readings=BME280Readings(temperature_c=21.4, humidity_pct=55.2, pressure_hpa=1013.25),
+                meta=Meta(sample_count=5, aggregation="median"),
+            )
+
+
+class TestSCD40Payload:
+    def test_valid(self):
+        p = SCD40Payload(
+            sensor_id="scd40",
+            timestamp=NOW_UTC,
+            readings=SCD40Readings(co2_ppm=415.0),
+            meta=Meta(sample_count=3, aggregation="median"),
+        )
+        assert p.readings.co2_ppm == 415.0
+
+    def test_wrong_sensor_id(self):
+        with pytest.raises(ValidationError):
+            SCD40Payload(
+                sensor_id="bme280",
+                timestamp=NOW_UTC,
+                readings=SCD40Readings(co2_ppm=415.0),
+                meta=Meta(sample_count=3, aggregation="median"),
+            )
+
+
+class TestAudioPayload:
+    def test_valid(self):
+        p = AudioPayload(
+            sensor_id="inmp441",
+            timestamp=NOW_UTC,
+            readings=AudioReadings(rms_amplitude=0.03, db_level=-30.5),
+            meta=Meta(sample_count=1, aggregation="rms"),
+        )
+        assert p.sensor_id == "inmp441"
+
+    def test_wrong_sensor_id(self):
+        with pytest.raises(ValidationError):
+            AudioPayload(
+                sensor_id="microphone",
+                timestamp=NOW_UTC,
+                readings=AudioReadings(rms_amplitude=0.03, db_level=-30.5),
+                meta=Meta(sample_count=1, aggregation="rms"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip JSON serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestJSONRoundTrip:
+    def test_bme280_roundtrip(self):
+        p = BME280Payload(
+            sensor_id="bme280",
+            timestamp=NOW_UTC,
+            readings=BME280Readings(temperature_c=21.4, humidity_pct=55.2, pressure_hpa=1013.25),
+            meta=Meta(sample_count=5, aggregation="median"),
+            diagnostics=Diagnostics(uptime_seconds=100, read_failures=0),
+        )
+        json_str = p.model_dump_json()
+        restored = BME280Payload.model_validate_json(json_str)
+        assert restored.readings.temperature_c == p.readings.temperature_c
+        assert restored.diagnostics.uptime_seconds == p.diagnostics.uptime_seconds
+
+    def test_audio_roundtrip(self):
+        p = AudioPayload(
+            sensor_id="inmp441",
+            timestamp=NOW_UTC,
+            readings=AudioReadings(rms_amplitude=0.05, db_level=-20.0),
+            meta=Meta(sample_count=1, aggregation="rms"),
+        )
+        json_str = p.model_dump_json()
+        restored = AudioPayload.model_validate_json(json_str)
+        assert restored.readings.db_level == p.readings.db_level

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,13 @@
 """Unit tests for common/models.py — no hardware required."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 import pytest
 from pydantic import ValidationError
 
 from common.models import (
+    _normalise_to_utc,
+    _UTCTimestampMixin,
     AudioPayload,
     AudioReadings,
     BME280Payload,
@@ -259,3 +261,92 @@ class TestJSONRoundTrip:
         json_str = p.model_dump_json()
         restored = AudioPayload.model_validate_json(json_str)
         assert restored.readings.db_level == p.readings.db_level
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: _normalise_to_utc shared helper and _UTCTimestampMixin
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseToUTC:
+    """Tests for the shared _normalise_to_utc helper (Bug 3 fix)."""
+
+    def test_naive_gets_utc(self):
+        naive = datetime(2026, 5, 8, 12, 0, 0)
+        result = _normalise_to_utc(naive)
+        assert result.tzinfo == timezone.utc
+        assert result.hour == 12  # value unchanged, zone attached
+
+    def test_utc_aware_unchanged(self):
+        utc = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+        result = _normalise_to_utc(utc)
+        assert result == utc
+
+    def test_non_utc_aware_converted(self):
+        eastern = timezone(timedelta(hours=-5))
+        dt = datetime(2026, 5, 8, 7, 0, 0, tzinfo=eastern)  # 07:00 UTC-5 == 12:00 UTC
+        result = _normalise_to_utc(dt)
+        assert result.tzinfo == timezone.utc
+        assert result.hour == 12
+
+    def test_positive_offset_converted(self):
+        berlin = timezone(timedelta(hours=2))
+        dt = datetime(2026, 5, 8, 14, 0, 0, tzinfo=berlin)  # 14:00 UTC+2 == 12:00 UTC
+        result = _normalise_to_utc(dt)
+        assert result.tzinfo == timezone.utc
+        assert result.hour == 12
+
+
+class TestUTCTimestampMixinInheritance:
+    """Verify all payload classes share the single ensure_utc validator (Bug 3 fix)."""
+
+    def _check_payload_normalises(self, PayloadClass, extra_kwargs):
+        """Confirm that a naive timestamp is UTC-normalised for *PayloadClass*."""
+        naive = datetime(2026, 1, 1, 6, 0, 0)
+        p = PayloadClass(timestamp=naive, **extra_kwargs)
+        assert p.timestamp.tzinfo == timezone.utc
+        assert p.timestamp.hour == 6
+
+    def _check_payload_converts_tz(self, PayloadClass, extra_kwargs):
+        """Confirm that a non-UTC aware timestamp is converted for *PayloadClass*."""
+        plus5 = timezone(timedelta(hours=5))
+        dt = datetime(2026, 1, 1, 11, 0, 0, tzinfo=plus5)  # 11:00 UTC+5 == 06:00 UTC
+        p = PayloadClass(timestamp=dt, **extra_kwargs)
+        assert p.timestamp.tzinfo == timezone.utc
+        assert p.timestamp.hour == 6
+
+    def test_sensor_payload_normalises(self):
+        kwargs = {
+            "sensor_id": "bme280",
+            "readings": BME280Readings(temperature_c=20, humidity_pct=50, pressure_hpa=1013),
+            "meta": Meta(sample_count=5, aggregation="median"),
+        }
+        self._check_payload_normalises(SensorPayload, kwargs)
+        self._check_payload_converts_tz(SensorPayload, kwargs)
+
+    def test_bme280_payload_normalises(self):
+        kwargs = {
+            "sensor_id": "bme280",
+            "readings": BME280Readings(temperature_c=20, humidity_pct=50, pressure_hpa=1013),
+            "meta": Meta(sample_count=5, aggregation="median"),
+        }
+        self._check_payload_normalises(BME280Payload, kwargs)
+        self._check_payload_converts_tz(BME280Payload, kwargs)
+
+    def test_scd40_payload_normalises(self):
+        kwargs = {
+            "sensor_id": "scd40",
+            "readings": SCD40Readings(co2_ppm=415.0),
+            "meta": Meta(sample_count=3, aggregation="median"),
+        }
+        self._check_payload_normalises(SCD40Payload, kwargs)
+        self._check_payload_converts_tz(SCD40Payload, kwargs)
+
+    def test_audio_payload_normalises(self):
+        kwargs = {
+            "sensor_id": "inmp441",
+            "readings": AudioReadings(rms_amplitude=0.03, db_level=-30.0),
+            "meta": Meta(sample_count=1, aggregation="rms"),
+        }
+        self._check_payload_normalises(AudioPayload, kwargs)
+        self._check_payload_converts_tz(AudioPayload, kwargs)

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -1,0 +1,171 @@
+"""Unit tests for common/mqtt.py — no broker required."""
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from common.mqtt import JsonFormatter, MQTTClient
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: _message_callbacks must store (callback, qos) and replay QoS on reconnect
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeStoresQoS:
+    def _make_client(self) -> MQTTClient:
+        return MQTTClient(client_id="test-client", broker_host="localhost")
+
+    def test_default_qos_stored(self):
+        client = self._make_client()
+        cb = lambda topic, payload: None
+        client.subscribe("home/sensors/#", cb)
+        stored_cb, stored_qos = client._message_callbacks["home/sensors/#"]
+        assert stored_cb is cb
+        assert stored_qos == 1  # the wrapper's default
+
+    def test_explicit_qos_stored(self):
+        client = self._make_client()
+        cb = lambda topic, payload: None
+        client.subscribe("home/sensors/#", cb, qos=2)
+        _, stored_qos = client._message_callbacks["home/sensors/#"]
+        assert stored_qos == 2
+
+    def test_qos_zero_stored(self):
+        client = self._make_client()
+        cb = lambda topic, payload: None
+        client.subscribe("home/sensors/#", cb, qos=0)
+        _, stored_qos = client._message_callbacks["home/sensors/#"]
+        assert stored_qos == 0
+
+    def test_reconnect_resubscribes_with_original_qos(self):
+        """_on_connect must forward the stored QoS, not default to QoS 0."""
+        client = self._make_client()
+        cb = lambda topic, payload: None
+        client.subscribe("home/sensors/#", cb, qos=2)
+
+        mock_paho = MagicMock()
+        client._client = mock_paho
+
+        mock_reason = MagicMock()
+        mock_reason.is_failure = False
+        client._on_connect(mock_paho, None, MagicMock(), mock_reason, None)
+
+        mock_paho.subscribe.assert_called_once_with("home/sensors/#", qos=2)
+
+    def test_reconnect_preserves_qos_for_multiple_subscriptions(self):
+        client = self._make_client()
+        cb1 = lambda t, p: None
+        cb2 = lambda t, p: None
+        client.subscribe("topic/a", cb1, qos=1)
+        client.subscribe("topic/b", cb2, qos=0)
+
+        mock_paho = MagicMock()
+        client._client = mock_paho
+
+        mock_reason = MagicMock()
+        mock_reason.is_failure = False
+        client._on_connect(mock_paho, None, MagicMock(), mock_reason, None)
+
+        calls = mock_paho.subscribe.call_args_list
+        assert call("topic/a", qos=1) in calls
+        assert call("topic/b", qos=0) in calls
+
+    def test_failed_reconnect_does_not_resubscribe(self):
+        """A failed connection attempt must not trigger re-subscription."""
+        client = self._make_client()
+        cb = lambda t, p: None
+        client.subscribe("home/#", cb, qos=1)
+
+        mock_paho = MagicMock()
+        client._client = mock_paho
+
+        mock_reason = MagicMock()
+        mock_reason.is_failure = True
+        client._on_connect(mock_paho, None, MagicMock(), mock_reason, None)
+
+        mock_paho.subscribe.assert_not_called()
+
+    def test_message_callback_invoked_correctly(self):
+        """_on_message must still dispatch to the callback after the tuple refactor."""
+        client = self._make_client()
+        received = []
+        client.subscribe("home/sensors/#", lambda t, p: received.append((t, p)), qos=1)
+
+        mock_msg = MagicMock()
+        mock_msg.topic = "home/sensors/climate/bme280"
+        mock_msg.payload = b'{"sensor_id": "bme280"}'
+        client._on_message(MagicMock(), None, mock_msg)
+
+        assert len(received) == 1
+        assert received[0][0] == "home/sensors/climate/bme280"
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: JsonFormatter.formatTime must produce UTC timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestJsonFormatterUTC:
+    def _make_record(self, *, epoch: float | None = None) -> logging.LogRecord:
+        record = logging.LogRecord(
+            name="test.service",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="hello",
+            args=(),
+            exc_info=None,
+        )
+        if epoch is not None:
+            record.created = epoch
+        return record
+
+    def test_formattime_returns_utc(self):
+        """formatTime must return UTC, not local time."""
+        # Use a known epoch: 2026-05-08 12:00:00 UTC == 1746705600
+        known_epoch = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+        record = self._make_record(epoch=known_epoch)
+        fmt = JsonFormatter()
+        result = fmt.formatTime(record)
+        assert result == "2026-05-08T12:00:00Z"
+
+    def test_formattime_ends_with_z(self):
+        record = self._make_record()
+        fmt = JsonFormatter()
+        result = fmt.formatTime(record)
+        assert result.endswith("Z"), f"Expected Z suffix, got: {result!r}"
+
+    def test_formattime_custom_datefmt(self):
+        known_epoch = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+        record = self._make_record(epoch=known_epoch)
+        fmt = JsonFormatter()
+        result = fmt.formatTime(record, datefmt="%Y/%m/%d %H:%M")
+        assert result == "2026/05/08 12:00"
+
+    def test_format_includes_utc_timestamp(self):
+        """The full format() output must have a correct UTC timestamp field."""
+        known_epoch = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+        record = self._make_record(epoch=known_epoch)
+        record.extra_event = "test_event"
+
+        fmt = JsonFormatter()
+        output = json.loads(fmt.format(record))
+        assert output["timestamp"] == "2026-05-08T12:00:00Z"
+
+    def test_formattime_independent_of_local_timezone(self):
+        """Patching time.localtime to a non-UTC zone must not affect output."""
+        known_epoch = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+        record = self._make_record(epoch=known_epoch)
+
+        fmt = JsonFormatter()
+        # Simulate a system configured to UTC+5 by patching time.localtime
+        with patch("time.localtime", return_value=time.gmtime(known_epoch + 5 * 3600)):
+            result = fmt.formatTime(record)
+
+        # Must still return the real UTC time, not UTC+5
+        assert result == "2026-05-08T12:00:00Z"

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -106,6 +106,33 @@ class TestSubscribeStoresQoS:
 
 
 # ---------------------------------------------------------------------------
+# publish() raises RuntimeError when not connected
+# ---------------------------------------------------------------------------
+
+
+class TestPublishConnectedGuard:
+    def test_publish_raises_when_disconnected(self):
+        client = MQTTClient(client_id="test-client", broker_host="localhost")
+        assert not client.is_connected
+        with pytest.raises(RuntimeError, match="not connected"):
+            client.publish("home/sensors/test", b"payload")
+
+    def test_publish_allowed_when_connected(self):
+        client = MQTTClient(client_id="test-client", broker_host="localhost")
+        client._connected = True
+
+        mock_result = MagicMock()
+        mock_result.wait_for_publish = MagicMock()
+        client._client = MagicMock()
+        client._client.publish.return_value = mock_result
+
+        client.publish("home/sensors/test", b"payload", qos=1, retain=True)
+        client._client.publish.assert_called_once_with(
+            "home/sensors/test", payload=b"payload", qos=1, retain=True
+        )
+
+
+# ---------------------------------------------------------------------------
 # Bug 4: JsonFormatter.formatTime must produce UTC timestamps
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR 1** from `docs/dev-plan.md`: establishes the monorepo skeleton and the `common/` shared library.

## Changes

### Repository structure
- `.gitignore`, `pyproject.toml` (`common` installable local package, `pydantic>=2.0`, `paho-mqtt>=2.0`)
- `config/global.toml` (shared broker and logging defaults)
- Directory stubs: `services/`, `scripts/`, `mosquitto/`

### `common/` library
- `common/config.py` — TOML loader, recursive deep merge, typed `BrokerConfig`/`LoggingConfig`/`GlobalConfig`, fail-fast validation
- `common/models.py` — `_normalise_to_utc` helper, `_UTCTimestampMixin`, standard `SensorPayload` envelope, `Meta`, `Diagnostics`, per-sensor reading and typed payload models
- `common/mqtt.py` — paho-mqtt v2 wrapper: `connect()`, `publish()` (guarded), `subscribe()` (stores QoS), `loop_start()`, auto-reconnect with QoS replay, UTC-correct `JsonFormatter`
- `common/i2c.py` — `I2CBase` with keyword-only required `address`, address validation, lazy hardware init, `I2CError`, context manager

### Tests: 88 passing, no warnings

---

## Bug fixes (commits 2–3, from bug report and self review)

| # | File | Bug | Fix |
|---|------|-----|-----|
| 1 | `mqtt.py` | `_message_callbacks` dropped QoS; reconnect re-subscribed at QoS 0 | Store `(callback, qos)` tuples; `_on_connect` replays stored QoS |
| 2 | `i2c.py` | `address=0x00` default always rejected by `_validate_address` | `address` is keyword-only required: `def __init__(self, bus=1, *, address: int)` |
| 3 | `models.py` | `ensure_utc` validator copied across four payload classes | Single `_normalise_to_utc()` + `_UTCTimestampMixin` base class |
| 4 | `mqtt.py` | `JsonFormatter.formatTime` used `time.localtime`; `Z` suffix was wrong on non-UTC hosts | Override `formatTime` using `datetime.fromtimestamp(..., tz=timezone.utc)` |
| 5 | `mqtt.py` | Unused `import time` after Bug 4 fix | Removed |
| 6 | `mqtt.py` | `publish()` docstring promised `RuntimeError` when disconnected; no check existed | Added `if not self._connected: raise RuntimeError(...)` guard |
| 7 | `mqtt.py` | `connect()` docstring said "blocking until connection accepted"; paho returns immediately after sending `CONNECT`; `CONNACK` is async | Rewrote docstring to accurately describe async behaviour |
| 8 | `i2c.py` | `__init__` logged "I2C bus initialised" before any hardware was touched (lazy init) | Changed event to `i2c_address_validated` with a message that makes deferred init explicit |
| 9 | `i2c.py` | `close()` logged "I2C bus closed" in `finally`, so it fired even when `deinit()` raised | Moved success log to `else` clause; `finally` only nulls the reference |
| 10 | `i2c.py` | `_device` initialized in `__init__` but never read or written at the base class level | Removed |
| 11 | `config.py` | `load_config` docstring implied all broker/logging validation happened at merge time | Clarified that only the global file is validated; local overrides are not re-checked |

## Acceptance Criteria

- [x] `pip install -e .` succeeds
- [x] All models importable
- [x] `python3 -m pytest tests/ -v` → **88 passed, 0 warnings**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

