### PR TITLE
PR 2: Mosquitto Setup & Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,37 @@ sudo bash scripts/setup.sh   # Install system packages and create virtualenvs
 sudo bash scripts/deploy.sh  # Install and start systemd services
 ```
 
+### Mosquitto smoke test
+
+After running `setup.sh`, verify the broker with a publish/subscribe round-trip:
+
+```bash
+# Terminal 1 — subscribe
+mosquitto_sub -h 127.0.0.1 -t 'test/#' -v
+
+# Terminal 2 — publish
+mosquitto_pub -h 127.0.0.1 -t 'test/hello' -m 'world'
+```
+
+Expected output in terminal 1:
+
+```
+test/hello world
+```
+
+Verify that connections from outside localhost are refused (replace `<pi-ip>` with the Pi's LAN address):
+
+```bash
+mosquitto_pub -h <pi-ip> -t 'test/hello' -m 'world'
+# Expected: Connection refused
+```
+
+View broker logs:
+
+```bash
+journalctl -u mosquitto -f
+```
+
 ---
 
 ## Configuration

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -19,9 +19,12 @@ allow_anonymous true
 # Retained messages survive a broker restart, so the API service reconstructs
 # its in-memory state immediately on reconnect without waiting for sensors to
 # re-publish.
-
-persistence true
-persistence_location /var/lib/mosquitto/
+#
+# NOTE: 'persistence true' and 'persistence_location /var/lib/mosquitto/' are
+# intentionally omitted here.  The Debian/Ubuntu default mosquitto.conf
+# already sets both, and Mosquitto treats duplicate single-value directives
+# across included files as a fatal error.  The defaults are correct for our
+# use-case, so no override is needed.
 
 # ---------------------------------------------------------------------------
 # Logging

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -1,7 +1,10 @@
 # Arkadia — Mosquitto broker configuration
 #
 # This file is installed to /etc/mosquitto/conf.d/arkadia.conf by setup.sh.
-# It takes precedence over /etc/mosquitto/mosquitto.conf defaults.
+# It is loaded after /etc/mosquitto/mosquitto.conf via include_dir.
+# Multi-value directives (e.g. log_dest) are additive across files.
+# Single-value directives must not be duplicated — Mosquitto treats them as
+# fatal errors (see the Persistence section below for an example).
 
 # ---------------------------------------------------------------------------
 # Network: bind to loopback only
@@ -29,9 +32,15 @@ allow_anonymous true
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
-# Write to stdout so that systemd captures all output via journald.
-# Use: journalctl -u mosquitto -f
+# Log to stdout only so that systemd/journald is the single log destination.
+# View with: journalctl -u mosquitto -f
+#
+# The Debian default mosquitto.conf sets 'log_dest file ...'.  Because
+# log_dest is additive, we must explicitly clear it with 'log_dest none'
+# before adding stdout, otherwise every log line is written to both the
+# journal and /var/log/mosquitto/mosquitto.log.
 
+log_dest none
 log_dest stdout
 log_type error
 log_type warning

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -1,0 +1,36 @@
+# Arkadia — Mosquitto broker configuration
+#
+# This file is installed to /etc/mosquitto/conf.d/arkadia.conf by setup.sh.
+# It takes precedence over /etc/mosquitto/mosquitto.conf defaults.
+
+# ---------------------------------------------------------------------------
+# Network: bind to loopback only
+# ---------------------------------------------------------------------------
+# All sensor services and the API run on the same Raspberry Pi.
+# Binding to 127.0.0.1 prevents any remote host from connecting to the broker,
+# removing it from the network attack surface entirely.
+
+listener 1883 127.0.0.1
+allow_anonymous true
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+# Retained messages survive a broker restart, so the API service reconstructs
+# its in-memory state immediately on reconnect without waiting for sensors to
+# re-publish.
+
+persistence true
+persistence_location /var/lib/mosquitto/
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+# Write to stdout so that systemd captures all output via journald.
+# Use: journalctl -u mosquitto -f
+
+log_dest stdout
+log_type error
+log_type warning
+log_type notice
+log_type information

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -63,9 +63,11 @@ enable_service() {
 
     # Give the broker a moment to come up before reporting status.
     sleep 1
-    systemctl is-active --quiet mosquitto \
-        && info "mosquitto.service is active." \
-        || die "mosquitto.service failed to start. Check: journalctl -u mosquitto -n 50"
+    if systemctl is-active --quiet mosquitto; then
+        info "mosquitto.service is active."
+    else
+        die "mosquitto.service failed to start. Check: journalctl -u mosquitto -n 50"
+    fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# setup.sh — Arkadia first-time system setup (partial: Mosquitto only)
+#
+# This is the partial version delivered in PR 2.  The complete script
+# (Python virtualenvs, I2C/I2S enablement, env file scaffold) is in PR 7.
+#
+# Must be run as root:  sudo bash scripts/setup.sh
+#
+# Idempotent — safe to re-run after a config change.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONF_SRC="${REPO_ROOT}/mosquitto/mosquitto.conf"
+CONF_DST="/etc/mosquitto/conf.d/arkadia.conf"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+info()  { echo "[setup] $*"; }
+die()   { echo "[setup] ERROR: $*" >&2; exit 1; }
+
+require_root() {
+    [[ "${EUID:-$(id -u)}" -eq 0 ]] || die "This script must be run as root."
+}
+
+# ---------------------------------------------------------------------------
+# Install Mosquitto
+# ---------------------------------------------------------------------------
+
+install_mosquitto() {
+    info "Updating package lists..."
+    apt-get update -qq
+
+    info "Installing mosquitto and mosquitto-clients..."
+    apt-get install -y -qq mosquitto mosquitto-clients
+}
+
+# ---------------------------------------------------------------------------
+# Install configuration
+# ---------------------------------------------------------------------------
+
+install_config() {
+    if [[ ! -f "${CONF_SRC}" ]]; then
+        die "mosquitto/mosquitto.conf not found at ${CONF_SRC}"
+    fi
+
+    info "Installing ${CONF_SRC} → ${CONF_DST}..."
+    install -m 644 "${CONF_SRC}" "${CONF_DST}"
+}
+
+# ---------------------------------------------------------------------------
+# Enable and start service
+# ---------------------------------------------------------------------------
+
+enable_service() {
+    info "Enabling mosquitto.service..."
+    systemctl enable mosquitto
+
+    info "Restarting mosquitto.service..."
+    systemctl restart mosquitto
+
+    # Give the broker a moment to come up before reporting status.
+    sleep 1
+    systemctl is-active --quiet mosquitto \
+        && info "mosquitto.service is active." \
+        || die "mosquitto.service failed to start. Check: journalctl -u mosquitto -n 50"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+require_root
+install_mosquitto
+install_config
+enable_service
+
+info "Done. Mosquitto is listening on 127.0.0.1:1883."
+info "Verify with:"
+info "  mosquitto_sub -h 127.0.0.1 -t 'test/#' &"
+info "  mosquitto_pub -h 127.0.0.1 -t 'test/hello' -m 'world'"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR 2** from `docs/dev-plan.md`: Mosquitto broker configuration and first-time setup script. Depends on PR 1 (merged).

## Changes

### `mosquitto/mosquitto.conf`
- `listener 1883 127.0.0.1` — binds to loopback only
- `allow_anonymous true` — no credentials needed for local services
- Persistence provided by Debian defaults (intentionally not duplicated — duplicate single-value directives are a fatal error)
- `log_dest none` + `log_dest stdout` — suppresses the Debian default file log and routes all output to stdout/journald only (`journalctl -u mosquitto -f`)

### `scripts/setup.sh` (partial)
- Idempotent — safe to re-run after a config change
- Installs `mosquitto` and `mosquitto-clients` via apt
- Installs `mosquitto/mosquitto.conf` → `/etc/mosquitto/conf.d/arkadia.conf`
- `systemctl enable mosquitto` + `systemctl restart mosquitto`
- Exits non-zero with a diagnostic if the service fails to start

### `README.md`
Added **Mosquitto smoke test** section with pub/sub round-trip and external-connection refusal verification steps.

---

## Bug fixes (commits 2–3)

| # | Where | Bug | Fix |
|---|-------|-----|-----|
| 1 | `mosquitto.conf` | `persistence true` / `persistence_location` duplicated Debian defaults; broker refused to start with "Duplicate persistence value" fatal error | Removed both directives; added explanatory comment |
| 2 | `mosquitto.conf` | Header comment said "takes precedence" — false; `conf.d` files are appended, not layered | Corrected comment to describe additive vs. fatal-duplicate behaviour |
| 3 | `mosquitto.conf` | `log_dest stdout` was additive with the Debian default `log_dest file ...`; every log line written to both journal and file | Added `log_dest none` before `log_dest stdout` to suppress the file destination; verified empirically |
| 4 | `setup.sh` | SC2015: `&& info ... \|\| die ...` is not if-then-else; `die` could fire if `info` failed while service was active | Replaced with `if/else`; `shellcheck` now clean |

## Acceptance Criteria

- [x] Broker starts with system config — no errors ✅
- [x] Pub/sub round-trip: `test/hello world` received ✅
- [x] External connection refused: `mosquitto_pub -h 172.30.0.2` → `Error: Connection refused` ✅
- [x] File log not written: `log_dest none` + `log_dest stdout` confirmed stdout-only ✅
- [x] `shellcheck` clean ✅

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

