### PR TITLE
PR 3: BME280 Sensor Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,25 @@ See [`docs/tech-design.md`](docs/tech-design.md) for the full technical design.
 
 ```
 arkadia/
-├── common/            # Shared library (config, models, MQTT, I2C)
+├── common/                    # Shared library (config, models, MQTT, I2C)
 ├── services/
-│   ├── bme280/        # Temperature / humidity / pressure service
-│   ├── scd40/         # CO₂ service
-│   ├── audio/         # Ambient sound service
-│   └── api/           # REST API service
+│   ├── bme280/
+│   │   ├── sensor.py          # BME280 driver (wraps adafruit-circuitpython-bme280)
+│   │   ├── main.py            # Polling loop + MQTT publish
+│   │   ├── config.toml        # Sensor and MQTT settings
+│   │   ├── bme280.service     # systemd unit file
+│   │   └── requirements.txt
+│   ├── scd40/                 # CO₂ service (pending)
+│   ├── audio/                 # Ambient sound service (pending)
+│   └── api/                   # REST API service (pending)
 ├── config/
-│   └── global.toml    # Shared broker and logging defaults
+│   └── global.toml            # Shared broker and logging defaults
 ├── mosquitto/
-│   └── mosquitto.conf # Broker configuration
+│   └── mosquitto.conf         # Broker configuration
 ├── scripts/
-│   ├── setup.sh       # First-time system setup
-│   └── deploy.sh      # Service deployment / restart
-├── tests/             # Unit tests (no hardware required)
+│   ├── setup.sh               # First-time system setup
+│   └── deploy.sh              # Service deployment / restart (pending)
+├── tests/                     # Unit tests (no hardware required)
 └── pyproject.toml
 ```
 
@@ -86,8 +91,18 @@ Verify I2C is up and your sensor is visible:
 ```bash
 sudo apt-get install -y i2c-tools
 i2cdetect -y 1
-# BME280 shows as 0x76 or 0x77
 ```
+
+You should see `76` or `77` in the grid output:
+
+```
+     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+00:                         -- -- -- -- -- -- -- -- --
+...
+70: -- -- -- -- -- -- 76 --
+```
+
+If your sensor appears at `77` (SDO pin pulled high), edit `services/bme280/config.toml` and change `i2c_address = 0x76` to `i2c_address = 0x77` before continuing.
 
 ### 2. Install system packages
 
@@ -146,20 +161,37 @@ Press Ctrl-C to stop the service once you have confirmed it is working.
 
 ### 6. Install and enable the systemd service
 
-The service file uses the `ARKADIA_ROOT` variable from `/etc/home-monitor.env` for all paths.  Before installing, update the `User=` line to match your actual username:
-
 ```bash
-# Edit the user if needed (default is 'pi')
-grep "User=" services/bme280/bme280.service
-
-# Copy the service file
+# Install the service file
 sudo cp services/bme280/bme280.service /etc/systemd/system/
+
+# Change the User= field in the installed copy to your actual username
+sudo sed -i "s/^User=pi$/User=$(whoami)/" /etc/systemd/system/bme280.service
+
+# Confirm it looks right
+grep "^User=" /etc/systemd/system/bme280.service
 
 # Reload systemd and enable
 sudo systemctl daemon-reload
 sudo systemctl enable bme280
 sudo systemctl start bme280
 ```
+
+> **Note for Pi 5 / adafruit-blinka:** `lgpio` (the GPIO backend) creates
+> temporary notification files in the service's working directory.
+> `bme280.service` already sets `RuntimeDirectory=bme280` and
+> `WorkingDirectory=/run/bme280` to give it a writable location.  If you
+> ever need to re-apply this fix to an already-installed service file (e.g.
+> after installing from an older commit), use a drop-in override:
+> ```bash
+> sudo mkdir -p /etc/systemd/system/bme280.service.d
+> sudo tee /etc/systemd/system/bme280.service.d/workdir.conf > /dev/null << 'EOF'
+> [Service]
+> RuntimeDirectory=bme280
+> WorkingDirectory=/run/bme280
+> EOF
+> sudo systemctl daemon-reload
+> ```
 
 ### 7. Verify
 

--- a/README.md
+++ b/README.md
@@ -43,19 +43,135 @@ arkadia/
 
 ---
 
-## Quick Start
+## Development Quick Start
 
-### Install the shared library
+These steps are for running the unit tests on any machine (no hardware required).
+
+Pi OS Bookworm (and any modern Debian/Ubuntu) enforces [PEP 668](https://peps.python.org/pep-0668/) — you cannot install packages into the system Python directly. Always use a virtual environment.
 
 ```bash
+# Create and activate a virtualenv
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install the common library in editable mode
 pip install -e .
-```
 
-### Run the tests
-
-```bash
+# Run the tests
 pip install pytest
 pytest
+```
+
+---
+
+## Deploying on Raspberry Pi
+
+### 1. Enable I2C
+
+```bash
+sudo raspi-config
+# → Interface Options → I2C → Enable
+# Reboot after enabling.
+```
+
+Or add the line directly and reboot:
+
+```bash
+echo "dtparam=i2c_arm=on" | sudo tee -a /boot/firmware/config.txt
+sudo reboot
+```
+
+Verify I2C is up and your sensor is visible:
+
+```bash
+sudo apt-get install -y i2c-tools
+i2cdetect -y 1
+# BME280 shows as 0x76 or 0x77
+```
+
+### 2. Install system packages
+
+```bash
+sudo bash scripts/setup.sh
+```
+
+This installs Mosquitto and applies `mosquitto/mosquitto.conf`.
+
+### 3. Create the environment file
+
+All services read `/etc/home-monitor.env` for the repository root path and any secrets.  Create it before enabling any service:
+
+```bash
+sudo tee /etc/home-monitor.env > /dev/null << EOF
+# Absolute path to the Arkadia repository on this machine.
+ARKADIA_ROOT=/home/$(whoami)/Projects/Arkadia
+EOF
+```
+
+Adjust the path to match where you cloned the repo.
+
+### 4. Set up the BME280 service virtualenv
+
+```bash
+cd services/bme280
+
+# Create a virtualenv dedicated to this service
+python3 -m venv .venv
+
+# Install the common library from the repo
+.venv/bin/pip install -e ../..
+
+# Install the sensor driver and hardware abstraction layer
+.venv/bin/pip install -r requirements.txt
+```
+
+### 5. Test the service manually before enabling systemd
+
+```bash
+# Make sure Mosquitto is running
+sudo systemctl start mosquitto
+
+# Run the service in the foreground — you should see JSON log lines
+# and retained MQTT messages after ~35 s (5 samples × 0.5 s + 30 s sleep)
+.venv/bin/python main.py
+```
+
+In another terminal, subscribe to verify the payload arrives:
+
+```bash
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/climate/bme280' -v
+```
+
+Press Ctrl-C to stop the service once you have confirmed it is working.
+
+### 6. Install and enable the systemd service
+
+The service file uses the `ARKADIA_ROOT` variable from `/etc/home-monitor.env` for all paths.  Before installing, update the `User=` line to match your actual username:
+
+```bash
+# Edit the user if needed (default is 'pi')
+grep "User=" services/bme280/bme280.service
+
+# Copy the service file
+sudo cp services/bme280/bme280.service /etc/systemd/system/
+
+# Reload systemd and enable
+sudo systemctl daemon-reload
+sudo systemctl enable bme280
+sudo systemctl start bme280
+```
+
+### 7. Verify
+
+```bash
+# Check service status
+sudo systemctl status bme280
+
+# Watch structured JSON logs
+journalctl -u bme280 -f
+
+# Watch the MQTT topic
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/climate/bme280' -v
 ```
 
 ---
@@ -70,14 +186,7 @@ pytest
 
 ---
 
-## Setup and Deploy
-
-```bash
-sudo bash scripts/setup.sh   # Install system packages and create virtualenvs
-sudo bash scripts/deploy.sh  # Install and start systemd services
-```
-
-### Mosquitto smoke test
+## Mosquitto smoke test
 
 After running `setup.sh`, verify the broker with a publish/subscribe round-trip:
 
@@ -114,7 +223,7 @@ journalctl -u mosquitto -f
 
 - Global defaults: `config/global.toml`
 - Per-service overrides: `services/<name>/config.toml`
-- Secrets: `/etc/home-monitor.env` (created by `setup.sh`)
+- Paths and secrets: `/etc/home-monitor.env`
 
 ---
 

--- a/common/mqtt.py
+++ b/common/mqtt.py
@@ -48,11 +48,19 @@ class JsonFormatter(logging.Formatter):
 
 
 def configure_logging(level: str = "INFO", fmt: str = "json") -> None:
-    """Configure the root logger with structured JSON or plain-text output."""
+    """Configure the root logger with structured JSON or plain-text output.
+
+    Explicitly replaces all existing handlers on the root logger so that this
+    function is not a no-op when called after :func:`logging.basicConfig` (or
+    any other logging setup) has already installed handlers.
+    """
     handler = logging.StreamHandler()
     if fmt == "json":
         handler.setFormatter(JsonFormatter())
-    logging.basicConfig(level=level.upper(), handlers=[handler])
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level.upper())
 
 
 # ---------------------------------------------------------------------------

--- a/services/bme280/bme280.service
+++ b/services/bme280/bme280.service
@@ -36,6 +36,14 @@ RestartSec=5
 # Allow up to 15 s for a clean shutdown (covers the worst-case poll cycle).
 TimeoutStopSec=15
 
+# Create /run/bme280 owned by the service user before starting.
+# This gives lgpio (the GPIO backend used by adafruit-blinka on Pi 5) a
+# writable directory for its named-pipe notification files (.lgd-nfy*).
+# Without this, lgpio tries to create those files in the default CWD (/),
+# which is read-only under ProtectSystem=full.
+RuntimeDirectory=bme280
+WorkingDirectory=/run/bme280
+
 # Log via journald.
 StandardOutput=journal
 StandardError=journal

--- a/services/bme280/bme280.service
+++ b/services/bme280/bme280.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Arkadia BME280 Climate Sensor Service
+Documentation=https://github.com/malonge/Arkadia
+After=mosquitto.service
+Requires=mosquitto.service
+
+[Service]
+Type=simple
+User=pi
+Group=i2c
+WorkingDirectory=/home/pi/Arkadia/services/bme280
+ExecStart=/home/pi/Arkadia/services/bme280/.venv/bin/python main.py
+Restart=on-failure
+RestartSec=5
+# Rate-limit restarts: no more than 5 restarts in 60 s.
+StartLimitIntervalSec=60
+StartLimitBurst=5
+# Allow up to 15 s for a clean shutdown (covers the worst-case poll cycle).
+TimeoutStopSec=15
+
+# Environment — secrets and overrides live outside the repo.
+# The leading '-' makes the file optional so the service starts without it.
+EnvironmentFile=-/etc/home-monitor.env
+
+# Log via journald.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bme280
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+# 'full' makes /usr, /boot, /etc read-only; /dev (I2C) remains accessible.
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/services/bme280/bme280.service
+++ b/services/bme280/bme280.service
@@ -11,18 +11,32 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
+
+# Change 'pi' to your actual username.
 User=pi
 Group=i2c
-WorkingDirectory=/home/pi/Arkadia/services/bme280
-ExecStart=/home/pi/Arkadia/services/bme280/.venv/bin/python main.py
+
+# /etc/home-monitor.env must exist and define ARKADIA_ROOT — the absolute
+# path to this repository on the target machine.  Example:
+#   ARKADIA_ROOT=/home/pi/Projects/Arkadia
+# systemd expands ${ARKADIA_ROOT} in ExecStart from this file.
+EnvironmentFile=/etc/home-monitor.env
+
+# Full paths are used here because WorkingDirectory= does not expand
+# environment variables.  sys.path in main.py ensures sensor.py is found
+# regardless of the working directory.
+#
+# Note: 'systemd-analyze verify' will report a false positive here because
+# that tool does not load EnvironmentFile during static analysis.  At
+# runtime the systemd daemon DOES expand ${ARKADIA_ROOT} from the env file
+# before executing the command.
+ExecStart=${ARKADIA_ROOT}/services/bme280/.venv/bin/python \
+          ${ARKADIA_ROOT}/services/bme280/main.py
+
 Restart=on-failure
 RestartSec=5
 # Allow up to 15 s for a clean shutdown (covers the worst-case poll cycle).
 TimeoutStopSec=15
-
-# Environment — secrets and overrides live outside the repo.
-# The leading '-' makes the file optional so the service starts without it.
-EnvironmentFile=-/etc/home-monitor.env
 
 # Log via journald.
 StandardOutput=journal

--- a/services/bme280/bme280.service
+++ b/services/bme280/bme280.service
@@ -3,6 +3,11 @@ Description=Arkadia BME280 Climate Sensor Service
 Documentation=https://github.com/malonge/Arkadia
 After=mosquitto.service
 Requires=mosquitto.service
+# Rate-limit restarts: no more than 5 restarts in 60 s.
+# Must be in [Unit] (not [Service]) on systemd 229+; in [Service] the keys
+# are silently ignored as "Unknown key name".
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -12,9 +17,6 @@ WorkingDirectory=/home/pi/Arkadia/services/bme280
 ExecStart=/home/pi/Arkadia/services/bme280/.venv/bin/python main.py
 Restart=on-failure
 RestartSec=5
-# Rate-limit restarts: no more than 5 restarts in 60 s.
-StartLimitIntervalSec=60
-StartLimitBurst=5
 # Allow up to 15 s for a clean shutdown (covers the worst-case poll cycle).
 TimeoutStopSec=15
 

--- a/services/bme280/bme280.service
+++ b/services/bme280/bme280.service
@@ -19,19 +19,17 @@ Group=i2c
 # /etc/home-monitor.env must exist and define ARKADIA_ROOT — the absolute
 # path to this repository on the target machine.  Example:
 #   ARKADIA_ROOT=/home/pi/Projects/Arkadia
-# systemd expands ${ARKADIA_ROOT} in ExecStart from this file.
 EnvironmentFile=/etc/home-monitor.env
 
-# Full paths are used here because WorkingDirectory= does not expand
-# environment variables.  sys.path in main.py ensures sensor.py is found
-# regardless of the working directory.
-#
-# Note: 'systemd-analyze verify' will report a false positive here because
-# that tool does not load EnvironmentFile during static analysis.  At
-# runtime the systemd daemon DOES expand ${ARKADIA_ROOT} from the env file
-# before executing the command.
-ExecStart=${ARKADIA_ROOT}/services/bme280/.venv/bin/python \
-          ${ARKADIA_ROOT}/services/bme280/main.py
+# ExecStart uses /bin/bash as the executable (always an absolute path that
+# systemd can validate at parse time).  Bash then inherits the environment
+# that systemd loaded from EnvironmentFile — including ARKADIA_ROOT — and
+# expands it inside the double-quoted exec string.  This sidesteps the
+# systemd limitation that env vars from EnvironmentFile are NOT expanded
+# when systemd itself validates the ExecStart executable path.
+ExecStart=/bin/bash -c \
+  'exec "${ARKADIA_ROOT}/services/bme280/.venv/bin/python" \
+        "${ARKADIA_ROOT}/services/bme280/main.py"'
 
 Restart=on-failure
 RestartSec=5

--- a/services/bme280/config.toml
+++ b/services/bme280/config.toml
@@ -1,0 +1,26 @@
+# BME280 service configuration.
+# Global broker and logging defaults are loaded from config/global.toml;
+# only service-specific values need to be set here.
+
+[sensor]
+# I2C bus number. On Raspberry Pi, bus 1 is the standard 40-pin header bus.
+i2c_bus = 1
+
+# 7-bit I2C address. BME280 is 0x76 when SDO is pulled low (default wiring)
+# or 0x77 when SDO is pulled high.
+i2c_address = 0x76
+
+# Number of raw samples to collect per polling cycle. Median is taken.
+sample_count = 5
+
+# Delay between individual samples within one cycle (seconds).
+sample_interval_seconds = 0.5
+
+# Time between successive publish cycles (seconds).
+interval_seconds = 30
+
+[mqtt]
+topic = "home/sensors/climate/bme280"
+client_id = "bme280-service"
+qos = 1
+retain = true

--- a/services/bme280/main.py
+++ b/services/bme280/main.py
@@ -24,6 +24,12 @@ from common.i2c import I2CError
 from common.models import BME280Payload, BME280Readings, Diagnostics, Meta
 from common.mqtt import MQTTClient, configure_logging
 
+# Ensure sensor.py is importable regardless of the working directory.
+# When running under systemd, WorkingDirectory is not set (to avoid
+# requiring it to expand env vars), so we add the service directory
+# to sys.path explicitly using __file__ which is always absolute.
+sys.path.insert(0, str(Path(__file__).parent))
+
 from sensor import BME280Sensor
 
 logger = logging.getLogger("bme280")

--- a/services/bme280/main.py
+++ b/services/bme280/main.py
@@ -40,14 +40,18 @@ def _handle_signal(signum: int, frame: object) -> None:
 
 
 def _wait_for_connect(client: MQTTClient, timeout: float = 15.0) -> bool:
-    """Block until the client is connected or *timeout* seconds elapse."""
+    """Block until the client is connected or *timeout* seconds elapse.
+
+    Uses ``_stop.wait`` so that a shutdown signal interrupts the wait
+    immediately rather than after the next 0.1 s tick.
+    """
     deadline = time.monotonic() + timeout
     while not client.is_connected:
         if time.monotonic() >= deadline:
             return False
         if _stop.is_set():
             return False
-        time.sleep(0.1)
+        _stop.wait(timeout=0.1)
     return True
 
 
@@ -55,11 +59,10 @@ def main() -> None:
     # ----------------------------------------------------------------
     # Logging bootstrap (plain text until config is loaded)
     # ----------------------------------------------------------------
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(levelname)s %(name)s %(message)s",
-        stream=sys.stderr,
-    )
+    # Use configure_logging (not logging.basicConfig) so the call after
+    # config is loaded actually replaces the handler with the JSON formatter
+    # rather than being silently ignored.
+    configure_logging(level="INFO", fmt="text")
 
     # ----------------------------------------------------------------
     # Configuration

--- a/services/bme280/main.py
+++ b/services/bme280/main.py
@@ -1,0 +1,255 @@
+"""BME280 climate sensor service.
+
+Polling loop:
+  1. Collect sample_count raw readings with sample_interval_seconds between them.
+  2. Compute median of each measurement across successful samples.
+  3. Build a BME280Payload using common/models.py.
+  4. Publish retained JSON to the configured MQTT topic.
+  5. Sleep for the remainder of the interval, waking immediately on SIGTERM.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import statistics
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from common.config import load_config
+from common.i2c import I2CError
+from common.models import BME280Payload, BME280Readings, Diagnostics, Meta
+from common.mqtt import MQTTClient, configure_logging
+
+from sensor import BME280Sensor
+
+logger = logging.getLogger("bme280")
+
+# Used by the signal handler to interrupt the inter-cycle sleep cleanly.
+_stop = threading.Event()
+
+
+def _handle_signal(signum: int, frame: object) -> None:
+    logger.info(
+        "Signal %d received — shutting down", signum, extra={"event": "service_shutdown"}
+    )
+    _stop.set()
+
+
+def _wait_for_connect(client: MQTTClient, timeout: float = 15.0) -> bool:
+    """Block until the client is connected or *timeout* seconds elapse."""
+    deadline = time.monotonic() + timeout
+    while not client.is_connected:
+        if time.monotonic() >= deadline:
+            return False
+        if _stop.is_set():
+            return False
+        time.sleep(0.1)
+    return True
+
+
+def main() -> None:
+    # ----------------------------------------------------------------
+    # Logging bootstrap (plain text until config is loaded)
+    # ----------------------------------------------------------------
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s %(message)s",
+        stream=sys.stderr,
+    )
+
+    # ----------------------------------------------------------------
+    # Configuration
+    # ----------------------------------------------------------------
+    config_path = Path(__file__).parent / "config.toml"
+    try:
+        cfg = load_config(config_path)
+    except Exception as exc:
+        logger.critical("Failed to load config from %s: %s", config_path, exc)
+        sys.exit(1)
+
+    # Reconfigure logging with settings from the merged config.
+    configure_logging(
+        level=cfg["logging"]["level"],
+        fmt=cfg["logging"]["format"],
+    )
+
+    logger.info(
+        "BME280 service starting", extra={"event": "service_started"}
+    )
+    logger.info(
+        "Config loaded from %s", config_path, extra={"event": "config_loaded"}
+    )
+
+    # ----------------------------------------------------------------
+    # Signal handling
+    # ----------------------------------------------------------------
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    # ----------------------------------------------------------------
+    # MQTT
+    # ----------------------------------------------------------------
+    broker = cfg["broker"]
+    mqtt_cfg = cfg["mqtt"]
+
+    client = MQTTClient(
+        client_id=mqtt_cfg["client_id"],
+        broker_host=broker["host"],
+        broker_port=broker["port"],
+        keepalive=broker["keepalive"],
+    )
+
+    try:
+        client.connect()
+    except Exception as exc:
+        logger.critical(
+            "Cannot reach MQTT broker at %s:%d: %s",
+            broker["host"],
+            broker["port"],
+            exc,
+        )
+        sys.exit(1)
+
+    client.loop_start()
+
+    if not _wait_for_connect(client):
+        logger.critical(
+            "Timed out waiting for MQTT connection to %s:%d",
+            broker["host"],
+            broker["port"],
+        )
+        client.loop_stop()
+        sys.exit(1)
+
+    # ----------------------------------------------------------------
+    # Hardware
+    # ----------------------------------------------------------------
+    sensor_cfg = cfg["sensor"]
+    sensor = BME280Sensor(
+        bus=sensor_cfg.get("i2c_bus", 1),
+        address=sensor_cfg["i2c_address"],
+    )
+
+    try:
+        sensor.open()
+    except I2CError as exc:
+        logger.critical("Sensor init failed: %s", exc, extra={"event": "sensor_error"})
+        client.loop_stop()
+        sys.exit(1)
+
+    # ----------------------------------------------------------------
+    # Poll loop
+    # ----------------------------------------------------------------
+    sample_count: int = sensor_cfg.get("sample_count", 5)
+    sample_interval: float = sensor_cfg.get("sample_interval_seconds", 0.5)
+    interval: float = sensor_cfg.get("interval_seconds", 30)
+    topic: str = mqtt_cfg["topic"]
+    qos: int = mqtt_cfg.get("qos", 1)
+    retain: bool = mqtt_cfg.get("retain", True)
+
+    service_start = time.monotonic()
+    read_failures = 0
+
+    logger.info(
+        "Entering poll loop (interval=%.0fs, samples=%d)",
+        interval,
+        sample_count,
+        extra={"event": "poll_loop_start"},
+    )
+
+    while not _stop.is_set():
+        cycle_start = time.monotonic()
+
+        # Collect samples
+        samples: list[dict[str, float]] = []
+        for i in range(sample_count):
+            try:
+                samples.append(sensor.read())
+                logger.debug(
+                    "Sample %d/%d: %.2f°C %.1f%% %.1fhPa",
+                    i + 1,
+                    sample_count,
+                    samples[-1]["temperature_c"],
+                    samples[-1]["humidity_pct"],
+                    samples[-1]["pressure_hpa"],
+                    extra={"event": "sensor_read"},
+                )
+            except I2CError as exc:
+                read_failures += 1
+                logger.warning(
+                    "Sample %d/%d failed: %s", i + 1, sample_count, exc,
+                    extra={"event": "sensor_error"},
+                )
+            if i < sample_count - 1:
+                _stop.wait(timeout=sample_interval)
+                if _stop.is_set():
+                    break
+
+        if not samples:
+            logger.error(
+                "All %d samples failed; skipping cycle", sample_count,
+                extra={"event": "sensor_error"},
+            )
+            _stop.wait(timeout=interval)
+            continue
+
+        # Compute medians
+        temperature_c = statistics.median(s["temperature_c"] for s in samples)
+        humidity_pct = statistics.median(s["humidity_pct"] for s in samples)
+        pressure_hpa = statistics.median(s["pressure_hpa"] for s in samples)
+
+        logger.info(
+            "Reading: %.2f°C  %.1f%%  %.1f hPa  (%d/%d samples)",
+            temperature_c,
+            humidity_pct,
+            pressure_hpa,
+            len(samples),
+            sample_count,
+            extra={"event": "sensor_read"},
+        )
+
+        # Build and publish payload
+        payload = BME280Payload(
+            sensor_id="bme280",
+            timestamp=datetime.now(tz=timezone.utc),
+            readings=BME280Readings(
+                temperature_c=temperature_c,
+                humidity_pct=humidity_pct,
+                pressure_hpa=pressure_hpa,
+            ),
+            meta=Meta(sample_count=len(samples), aggregation="median"),
+            diagnostics=Diagnostics(
+                uptime_seconds=time.monotonic() - service_start,
+                read_failures=read_failures,
+            ),
+        )
+
+        try:
+            client.publish(topic, payload.model_dump_json(), qos=qos, retain=retain)
+        except RuntimeError as exc:
+            logger.error(
+                "Publish failed: %s", exc, extra={"event": "mqtt_publish_error"}
+            )
+
+        # Sleep for the remainder of the cycle interval.
+        elapsed = time.monotonic() - cycle_start
+        remaining = interval - elapsed
+        if remaining > 0:
+            _stop.wait(timeout=remaining)
+
+    # ----------------------------------------------------------------
+    # Shutdown
+    # ----------------------------------------------------------------
+    logger.info("Stopping poll loop", extra={"event": "service_shutdown"})
+    sensor.close()
+    client.loop_stop()
+    client.disconnect()
+    logger.info("BME280 service stopped", extra={"event": "service_stopped"})
+
+
+if __name__ == "__main__":
+    main()

--- a/services/bme280/requirements.txt
+++ b/services/bme280/requirements.txt
@@ -1,0 +1,4 @@
+# Hardware abstraction layer for CircuitPython on Raspberry Pi
+adafruit-blinka
+# BME280 temperature / humidity / pressure sensor driver
+adafruit-circuitpython-bme280

--- a/services/bme280/sensor.py
+++ b/services/bme280/sensor.py
@@ -1,0 +1,94 @@
+"""BME280 sensor driver — wraps adafruit-circuitpython-bme280."""
+
+from __future__ import annotations
+
+import logging
+
+from common.i2c import I2CBase, I2CError
+
+logger = logging.getLogger(__name__)
+
+
+class BME280Sensor(I2CBase):
+    """Read temperature, humidity, and pressure from a BME280 over I2C.
+
+    Hardware is initialised lazily on the first :meth:`read` call so that the
+    module can be imported and the object constructed without hardware present
+    (useful in tests).  Call :meth:`open` explicitly if you want to fail fast
+    at startup rather than on the first poll cycle.
+
+    Example::
+
+        sensor = BME280Sensor(address=0x76)
+        sensor.open()
+        data = sensor.read()
+        # {"temperature_c": 21.4, "humidity_pct": 55.2, "pressure_hpa": 1013.25}
+    """
+
+    def __init__(self, bus: int = 1, *, address: int = 0x76) -> None:
+        super().__init__(bus=bus, address=address)
+        self._bme280 = None
+
+    # ------------------------------------------------------------------
+    # Hardware lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        """Explicitly initialise hardware.  Raises :class:`~common.i2c.I2CError` on failure."""
+        self._init_hardware()
+
+    def _init_hardware(self) -> None:
+        """Open the I2C bus and initialise the BME280 device object."""
+        try:
+            import board  # type: ignore[import-untyped]
+            import busio  # type: ignore[import-untyped]
+            import adafruit_bme280.basic as adafruit_bme280  # type: ignore[import-untyped]
+
+            self._i2c = busio.I2C(board.SCL, board.SDA)
+            self._bme280 = adafruit_bme280.Adafruit_BME280_I2C(
+                self._i2c, address=self._address
+            )
+            logger.info(
+                "BME280 ready at I2C address 0x%02X (bus %d)",
+                self._address,
+                self._bus,
+                extra={"event": "i2c_bus_open"},
+            )
+        except I2CError:
+            raise
+        except Exception as exc:
+            raise I2CError(
+                f"Failed to initialise BME280 at 0x{self._address:02X} on bus {self._bus}: {exc}"
+            ) from exc
+
+    def close(self) -> None:
+        """Release the BME280 device and the underlying I2C bus."""
+        self._bme280 = None
+        super().close()
+
+    # ------------------------------------------------------------------
+    # Sensor reading
+    # ------------------------------------------------------------------
+
+    def read(self) -> dict[str, float]:
+        """Return one sample from the BME280.
+
+        Returns a dict with keys ``temperature_c``, ``humidity_pct``, and
+        ``pressure_hpa``.
+
+        Hardware is initialised on the first call if :meth:`open` was not
+        called explicitly.
+
+        Raises :class:`~common.i2c.I2CError` on any hardware failure.
+        """
+        if self._bme280 is None:
+            self._init_hardware()
+
+        try:
+            return {
+                "temperature_c": float(self._bme280.temperature),
+                "humidity_pct": float(self._bme280.relative_humidity),
+                "pressure_hpa": float(self._bme280.pressure),
+            }
+        except Exception as exc:
+            raise I2CError(f"BME280 read failed: {exc}") from exc

--- a/services/bme280/sensor.py
+++ b/services/bme280/sensor.py
@@ -57,6 +57,15 @@ class BME280Sensor(I2CBase):
         except I2CError:
             raise
         except Exception as exc:
+            # If the I2C bus was opened but the BME280 device init failed,
+            # close the bus now so that a subsequent _init_hardware() call
+            # does not open a second bus on top of the leaked first one.
+            if self._i2c is not None:
+                try:
+                    self._i2c.deinit()
+                except Exception:
+                    pass
+                self._i2c = None
             raise I2CError(
                 f"Failed to initialise BME280 at 0x{self._address:02X} on bus {self._bus}: {exc}"
             ) from exc

--- a/tests/test_bme280.py
+++ b/tests/test_bme280.py
@@ -1,0 +1,331 @@
+"""Unit tests for the BME280 sensor service — no hardware required.
+
+Strategy: adafruit_bme280, board, and busio are not installed in the CI
+environment.  We inject fakes into sys.modules before importing sensor.py
+so that the module-level imports (which are deferred to _init_hardware())
+resolve to our fakes when the tests force hardware init.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from pydantic import ValidationError
+
+# ---------------------------------------------------------------------------
+# Ensure the services/bme280 directory is on sys.path so we can import
+# sensor.py and main.py directly (they are not installed packages).
+# ---------------------------------------------------------------------------
+
+SERVICE_DIR = Path(__file__).resolve().parent.parent / "services" / "bme280"
+if str(SERVICE_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVICE_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Fake hardware modules injected into sys.modules
+# ---------------------------------------------------------------------------
+
+def _make_fake_adafruit_bme280(temperature=21.5, humidity=55.0, pressure=1013.25):
+    """Build a fake adafruit_bme280.basic module whose device returns fixed values."""
+    fake_device = MagicMock()
+    fake_device.temperature = temperature
+    fake_device.relative_humidity = humidity
+    fake_device.pressure = pressure
+
+    fake_cls = MagicMock(return_value=fake_device)
+
+    fake_basic = types.ModuleType("adafruit_bme280.basic")
+    fake_basic.Adafruit_BME280_I2C = fake_cls
+
+    fake_top = types.ModuleType("adafruit_bme280")
+    fake_top.basic = fake_basic
+
+    return fake_top, fake_basic, fake_device
+
+
+def _make_fake_board_busio():
+    fake_board = types.ModuleType("board")
+    fake_board.SCL = MagicMock(name="SCL")
+    fake_board.SDA = MagicMock(name="SDA")
+
+    fake_i2c_instance = MagicMock(name="I2CInstance")
+    fake_busio = types.ModuleType("busio")
+    fake_busio.I2C = MagicMock(return_value=fake_i2c_instance)
+
+    return fake_board, fake_busio, fake_i2c_instance
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _inject_fakes(temperature=21.5, humidity=55.0, pressure=1013.25):
+    """Inject fake hardware modules and return (fake_top, fake_basic, fake_device)."""
+    fake_board, fake_busio, fake_i2c = _make_fake_board_busio()
+    fake_top, fake_basic, fake_device = _make_fake_adafruit_bme280(
+        temperature, humidity, pressure
+    )
+    sys.modules.update(
+        {
+            "board": fake_board,
+            "busio": fake_busio,
+            "adafruit_bme280": fake_top,
+            "adafruit_bme280.basic": fake_basic,
+        }
+    )
+    return fake_device, fake_busio
+
+
+def _remove_fakes():
+    for mod in ("board", "busio", "adafruit_bme280", "adafruit_bme280.basic"):
+        sys.modules.pop(mod, None)
+
+
+# ---------------------------------------------------------------------------
+# BME280Sensor tests
+# ---------------------------------------------------------------------------
+
+class TestBME280SensorConstruction:
+    def test_default_address(self):
+        from sensor import BME280Sensor
+        s = BME280Sensor(address=0x76)
+        assert s._address == 0x76
+        assert s._bus == 1
+
+    def test_custom_address(self):
+        from sensor import BME280Sensor
+        s = BME280Sensor(bus=1, address=0x77)
+        assert s._address == 0x77
+
+    def test_invalid_address_raises(self):
+        from sensor import BME280Sensor
+        from common.i2c import I2CError
+        with pytest.raises(I2CError):
+            BME280Sensor(address=0x00)
+
+    def test_no_hardware_contact_on_construction(self):
+        """Constructing BME280Sensor must not touch hardware."""
+        _remove_fakes()  # ensure hardware modules are absent
+        from sensor import BME280Sensor
+        # Should not raise even though adafruit libs are not installed
+        s = BME280Sensor(address=0x76)
+        assert s._bme280 is None
+
+    def test_address_required_keyword_only(self):
+        from sensor import BME280Sensor
+        with pytest.raises(TypeError):
+            BME280Sensor(1, 0x76)  # positional address not allowed
+
+
+class TestBME280SensorRead:
+    def setup_method(self):
+        _remove_fakes()
+        # Re-import sensor fresh so module-level state is clean.
+        if "sensor" in sys.modules:
+            del sys.modules["sensor"]
+
+    def teardown_method(self):
+        _remove_fakes()
+        if "sensor" in sys.modules:
+            del sys.modules["sensor"]
+
+    def test_read_returns_expected_keys(self):
+        fake_device, _ = _inject_fakes(temperature=21.5, humidity=55.0, pressure=1013.25)
+        from sensor import BME280Sensor
+        s = BME280Sensor(address=0x76)
+        data = s.read()
+        assert set(data.keys()) == {"temperature_c", "humidity_pct", "pressure_hpa"}
+
+    def test_read_values_are_floats(self):
+        fake_device, _ = _inject_fakes(temperature=21, humidity=55, pressure=1013)
+        from sensor import BME280Sensor
+        s = BME280Sensor(address=0x76)
+        data = s.read()
+        assert isinstance(data["temperature_c"], float)
+        assert isinstance(data["humidity_pct"], float)
+        assert isinstance(data["pressure_hpa"], float)
+
+    def test_read_returns_correct_values(self):
+        fake_device, _ = _inject_fakes(temperature=22.3, humidity=48.7, pressure=1020.1)
+        from sensor import BME280Sensor
+        s = BME280Sensor(address=0x76)
+        data = s.read()
+        assert data["temperature_c"] == pytest.approx(22.3, abs=0.01)
+        assert data["humidity_pct"] == pytest.approx(48.7, abs=0.01)
+        assert data["pressure_hpa"] == pytest.approx(1020.1, abs=0.01)
+
+    def test_read_inits_hardware_lazily(self):
+        fake_device, fake_busio = _inject_fakes()
+        from sensor import BME280Sensor
+        s = BME280Sensor(address=0x76)
+        assert s._bme280 is None  # not yet initialised
+        s.read()
+        assert s._bme280 is not None  # initialised on first read
+        assert fake_busio.I2C.call_count == 1
+
+    def test_open_inits_hardware_eagerly(self):
+        fake_device, fake_busio = _inject_fakes()
+        from sensor import BME280Sensor
+        s = BME280Sensor(address=0x76)
+        s.open()
+        assert s._bme280 is not None
+        assert fake_busio.I2C.call_count == 1
+
+    def test_read_hardware_error_raises_i2c_error(self):
+        _inject_fakes()
+        from sensor import BME280Sensor
+        from common.i2c import I2CError
+        s = BME280Sensor(address=0x76)
+        s.open()
+        # Make the .temperature property raise on access (not on call).
+        type(s._bme280).temperature = PropertyMock(side_effect=OSError("I2C failure"))
+        with pytest.raises(I2CError, match="BME280 read failed"):
+            s.read()
+
+    def test_close_clears_bme280(self):
+        _inject_fakes()
+        from sensor import BME280Sensor
+        s = BME280Sensor(address=0x76)
+        s.open()
+        assert s._bme280 is not None
+        s.close()
+        assert s._bme280 is None
+
+
+# ---------------------------------------------------------------------------
+# Payload model validation (core correctness check for real Pi data)
+# ---------------------------------------------------------------------------
+
+class TestBME280PayloadBuilding:
+    """Verify that the values produced by a sensor read pass Pydantic validation."""
+
+    def _make_payload(self, temperature_c=21.5, humidity_pct=55.0, pressure_hpa=1013.25):
+        from common.models import BME280Payload, BME280Readings, Diagnostics, Meta
+        return BME280Payload(
+            sensor_id="bme280",
+            timestamp=datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc),
+            readings=BME280Readings(
+                temperature_c=temperature_c,
+                humidity_pct=humidity_pct,
+                pressure_hpa=pressure_hpa,
+            ),
+            meta=Meta(sample_count=5, aggregation="median"),
+            diagnostics=Diagnostics(uptime_seconds=120.0, read_failures=0),
+        )
+
+    def test_valid_payload(self):
+        p = self._make_payload()
+        assert p.sensor_id == "bme280"
+        assert p.readings.temperature_c == 21.5
+
+    def test_payload_json_roundtrip(self):
+        from common.models import BME280Payload
+        p = self._make_payload()
+        restored = BME280Payload.model_validate_json(p.model_dump_json())
+        assert restored.readings.pressure_hpa == pytest.approx(1013.25)
+
+    def test_invalid_humidity_rejected(self):
+        with pytest.raises(ValidationError):
+            self._make_payload(humidity_pct=105.0)
+
+    def test_invalid_pressure_rejected(self):
+        with pytest.raises(ValidationError):
+            self._make_payload(pressure_hpa=0.0)
+
+    def test_payload_schema_version(self):
+        p = self._make_payload()
+        data = json.loads(p.model_dump_json())
+        assert data["schema_version"] == 1
+
+    def test_payload_topic_in_config(self):
+        """Smoke-test that the config.toml topic matches the expected MQTT path."""
+        import tomllib
+        config_path = SERVICE_DIR / "config.toml"
+        with config_path.open("rb") as fh:
+            cfg = tomllib.load(fh)
+        assert cfg["mqtt"]["topic"] == "home/sensors/climate/bme280"
+        assert cfg["mqtt"]["retain"] is True
+        assert cfg["mqtt"]["qos"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Median aggregation logic
+# ---------------------------------------------------------------------------
+
+class TestMedianAggregation:
+    """Test the aggregation logic used in main.py independent of hardware."""
+
+    def test_median_of_five(self):
+        samples = [
+            {"temperature_c": 21.0, "humidity_pct": 50.0, "pressure_hpa": 1010.0},
+            {"temperature_c": 21.2, "humidity_pct": 51.0, "pressure_hpa": 1011.0},
+            {"temperature_c": 21.4, "humidity_pct": 52.0, "pressure_hpa": 1012.0},
+            {"temperature_c": 21.6, "humidity_pct": 53.0, "pressure_hpa": 1013.0},
+            {"temperature_c": 21.8, "humidity_pct": 54.0, "pressure_hpa": 1014.0},
+        ]
+        temp = statistics.median(s["temperature_c"] for s in samples)
+        hum = statistics.median(s["humidity_pct"] for s in samples)
+        pres = statistics.median(s["pressure_hpa"] for s in samples)
+        assert temp == pytest.approx(21.4)
+        assert hum == pytest.approx(52.0)
+        assert pres == pytest.approx(1012.0)
+
+    def test_median_with_outlier(self):
+        """Median should be robust to a single outlier reading."""
+        samples = [
+            {"temperature_c": 21.0, "humidity_pct": 50.0, "pressure_hpa": 1010.0},
+            {"temperature_c": 21.1, "humidity_pct": 50.5, "pressure_hpa": 1010.5},
+            {"temperature_c": 99.9, "humidity_pct": 99.9, "pressure_hpa": 9999.0},  # outlier
+            {"temperature_c": 21.2, "humidity_pct": 50.8, "pressure_hpa": 1011.0},
+            {"temperature_c": 21.3, "humidity_pct": 51.0, "pressure_hpa": 1011.5},
+        ]
+        temp = statistics.median(s["temperature_c"] for s in samples)
+        assert temp == pytest.approx(21.2)
+
+    def test_median_with_partial_failures(self):
+        """If some samples fail, median is computed on the survivors."""
+        samples = [
+            {"temperature_c": 20.0, "humidity_pct": 48.0, "pressure_hpa": 1009.0},
+            {"temperature_c": 20.2, "humidity_pct": 49.0, "pressure_hpa": 1010.0},
+            # one sample dropped due to read failure
+        ]
+        temp = statistics.median(s["temperature_c"] for s in samples)
+        assert temp == pytest.approx(20.1)
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestBME280Config:
+    def test_config_loads_without_error(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["sensor"]["i2c_bus"] == 1
+        assert cfg["sensor"]["i2c_address"] == 0x76
+        assert cfg["sensor"]["sample_count"] == 5
+        assert cfg["sensor"]["interval_seconds"] == 30
+        assert cfg["mqtt"]["topic"] == "home/sensors/climate/bme280"
+
+    def test_global_broker_defaults_merged(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        # Global defaults should be present after merge
+        assert cfg["broker"]["host"] == "localhost"
+        assert cfg["broker"]["port"] == 1883
+
+    def test_i2c_address_is_valid(self):
+        """The configured I2C address must be accepted by I2CBase._validate_address."""
+        from common.i2c import I2CBase
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        # Should not raise
+        I2CBase._validate_address(cfg["sensor"]["i2c_address"])

--- a/tests/test_bme280.py
+++ b/tests/test_bme280.py
@@ -199,6 +199,43 @@ class TestBME280SensorRead:
         s.close()
         assert s._bme280 is None
 
+    def test_partial_init_failure_does_not_leak_i2c_bus(self):
+        """If BME280 device init fails after I2C bus opens, the bus must be closed.
+
+        Without the fix, _i2c would be left set on the first failure, and a
+        subsequent call to _init_hardware() (via read()) would open a second
+        I2C bus without closing the first.
+        """
+        fake_board, fake_busio, fake_i2c = _make_fake_board_busio()
+        # Make Adafruit_BME280_I2C fail so only the bus is opened
+        fail_bme280 = types.ModuleType("adafruit_bme280.basic")
+        fail_bme280.Adafruit_BME280_I2C = MagicMock(side_effect=ValueError("no device"))
+        fail_top = types.ModuleType("adafruit_bme280")
+        fail_top.basic = fail_bme280
+        sys.modules.update({
+            "board": fake_board, "busio": fake_busio,
+            "adafruit_bme280": fail_top, "adafruit_bme280.basic": fail_bme280,
+        })
+
+        from sensor import BME280Sensor
+        from common.i2c import I2CError
+
+        s = BME280Sensor(address=0x76)
+
+        # First attempt fails
+        with pytest.raises(I2CError):
+            s._init_hardware()
+
+        assert s._i2c is None, "_i2c must be cleaned up after partial failure"
+        assert fake_i2c.deinit.call_count == 1, "deinit must be called on the leaked bus"
+
+        # Second attempt must not open a second bus on top of the first
+        with pytest.raises(I2CError):
+            s._init_hardware()
+
+        assert fake_busio.I2C.call_count == 2, "two attempts = two bus opens"
+        assert fake_i2c.deinit.call_count == 2, "second bus must also be cleaned up"
+
 
 # ---------------------------------------------------------------------------
 # Payload model validation (core correctness check for real Pi data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,6 @@ from pydantic import ValidationError
 
 from common.models import (
     _normalise_to_utc,
-    _UTCTimestampMixin,
     AudioPayload,
     AudioReadings,
     BME280Payload,

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -21,31 +21,31 @@ class TestSubscribeStoresQoS:
         return MQTTClient(client_id="test-client", broker_host="localhost")
 
     def test_default_qos_stored(self):
+        def cb(topic, payload): pass
         client = self._make_client()
-        cb = lambda topic, payload: None
         client.subscribe("home/sensors/#", cb)
         stored_cb, stored_qos = client._message_callbacks["home/sensors/#"]
         assert stored_cb is cb
         assert stored_qos == 1  # the wrapper's default
 
     def test_explicit_qos_stored(self):
+        def cb(topic, payload): pass
         client = self._make_client()
-        cb = lambda topic, payload: None
         client.subscribe("home/sensors/#", cb, qos=2)
         _, stored_qos = client._message_callbacks["home/sensors/#"]
         assert stored_qos == 2
 
     def test_qos_zero_stored(self):
+        def cb(topic, payload): pass
         client = self._make_client()
-        cb = lambda topic, payload: None
         client.subscribe("home/sensors/#", cb, qos=0)
         _, stored_qos = client._message_callbacks["home/sensors/#"]
         assert stored_qos == 0
 
     def test_reconnect_resubscribes_with_original_qos(self):
         """_on_connect must forward the stored QoS, not default to QoS 0."""
+        def cb(topic, payload): pass
         client = self._make_client()
-        cb = lambda topic, payload: None
         client.subscribe("home/sensors/#", cb, qos=2)
 
         mock_paho = MagicMock()
@@ -58,9 +58,9 @@ class TestSubscribeStoresQoS:
         mock_paho.subscribe.assert_called_once_with("home/sensors/#", qos=2)
 
     def test_reconnect_preserves_qos_for_multiple_subscriptions(self):
+        def cb1(t, p): pass
+        def cb2(t, p): pass
         client = self._make_client()
-        cb1 = lambda t, p: None
-        cb2 = lambda t, p: None
         client.subscribe("topic/a", cb1, qos=1)
         client.subscribe("topic/b", cb2, qos=0)
 
@@ -77,8 +77,8 @@ class TestSubscribeStoresQoS:
 
     def test_failed_reconnect_does_not_resubscribe(self):
         """A failed connection attempt must not trigger re-subscription."""
+        def cb(t, p): pass
         client = self._make_client()
-        cb = lambda t, p: None
         client.subscribe("home/#", cb, qos=1)
 
         mock_paho = MagicMock()
@@ -94,7 +94,8 @@ class TestSubscribeStoresQoS:
         """_on_message must still dispatch to the callback after the tuple refactor."""
         client = self._make_client()
         received = []
-        client.subscribe("home/sensors/#", lambda t, p: received.append((t, p)), qos=1)
+        def collect(t, p): received.append((t, p))
+        client.subscribe("home/sensors/#", collect, qos=1)
 
         mock_msg = MagicMock()
         mock_msg.topic = "home/sensors/climate/bme280"

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import sys
 import time
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch, call
@@ -104,6 +105,56 @@ class TestSubscribeStoresQoS:
 
         assert len(received) == 1
         assert received[0][0] == "home/sensors/climate/bme280"
+
+
+# ---------------------------------------------------------------------------
+# configure_logging replaces existing handlers (not a basicConfig no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureLogging:
+    def setup_method(self):
+        # Capture root logger state before each test
+        self._original_handlers = logging.root.handlers[:]
+        self._original_level = logging.root.level
+
+    def teardown_method(self):
+        # Restore root logger so other tests are unaffected
+        logging.root.handlers.clear()
+        for h in self._original_handlers:
+            logging.root.addHandler(h)
+        logging.root.setLevel(self._original_level)
+
+    def test_installs_json_formatter_even_after_basicconfig(self):
+        """configure_logging must replace handlers, not skip due to basicConfig no-op."""
+        import logging as _logging
+        # Simulate what main.py's bootstrap used to do
+        _logging.basicConfig(level=_logging.INFO, stream=sys.stderr)
+        assert len(_logging.root.handlers) >= 1
+
+        from common.mqtt import configure_logging, JsonFormatter
+        configure_logging(level="INFO", fmt="json")
+
+        assert len(_logging.root.handlers) == 1
+        assert isinstance(_logging.root.handlers[0].formatter, JsonFormatter)
+
+    def test_replaces_all_existing_handlers(self):
+        import logging as _logging
+        # Install two handlers first
+        _logging.root.addHandler(_logging.StreamHandler())
+        _logging.root.addHandler(_logging.StreamHandler())
+        assert len(_logging.root.handlers) >= 2
+
+        from common.mqtt import configure_logging
+        configure_logging(level="DEBUG", fmt="json")
+
+        assert len(_logging.root.handlers) == 1
+        assert _logging.root.level == _logging.DEBUG
+
+    def test_text_format_has_no_json_formatter(self):
+        from common.mqtt import configure_logging, JsonFormatter
+        configure_logging(level="INFO", fmt="text")
+        assert not isinstance(logging.root.handlers[0].formatter, JsonFormatter)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR 3** from `docs/dev-plan.md`: the BME280 climate sensor service, end-to-end from I2C hardware to retained MQTT JSON. **Verified working on a Raspberry Pi 5 with a real BME280 sensor.**

---

## Files

### `services/bme280/sensor.py`
`BME280Sensor(I2CBase)` — lazy hardware init, `open()` for fail-fast startup, `read()` → `{temperature_c, humidity_pct, pressure_hpa}`, all errors wrapped in `I2CError`.

### `services/bme280/main.py`
Config → JSON logging → MQTT connect → `sensor.open()` → poll loop (5-sample median → `BME280Payload` → retained publish → sleep). `threading.Event` for immediate SIGTERM response. `sys.path` manipulation so `sensor.py` is importable without depending on `WorkingDirectory`.

### `services/bme280/config.toml`
`i2c_address=0x76`, `sample_count=5`, `interval_seconds=30`, topic `home/sensors/climate/bme280`, QoS 1, `retain=true`.

### `services/bme280/bme280.service`
- `After/Requires=mosquitto.service`
- `User=pi` (change to actual username before installing)
- `EnvironmentFile=/etc/home-monitor.env` — provides `ARKADIA_ROOT`
- `ExecStart=/bin/bash -c '...'` — bash expands `${ARKADIA_ROOT}` at runtime; avoids the systemd parse-time validation failure that occurs with env vars in bare `ExecStart` paths
- `RuntimeDirectory=bme280` + `WorkingDirectory=/run/bme280` — required for `lgpio` (adafruit-blinka's Pi 5 GPIO backend) to create its notification pipe files in a writable location; without this, lgpio attempts to create them in `/` which is read-only under `ProtectSystem=full`
- `StartLimitIntervalSec`/`StartLimitBurst` in `[Unit]` (not `[Service]`, where they are silently ignored on systemd 229+)
- `ProtectSystem=full`, `PrivateTmp=true`, `NoNewPrivileges=true`

### `services/bme280/requirements.txt`
`adafruit-blinka`, `adafruit-circuitpython-bme280`

---

## Deploying on Raspberry Pi

See the [README](README.md#deploying-on-raspberry-pi) for full step-by-step instructions. Quick summary:

```bash
# 1. Enable I2C and reboot
# 2. sudo bash scripts/setup.sh
# 3. sudo tee /etc/home-monitor.env <<< "ARKADIA_ROOT=$(pwd)"
# 4. cd services/bme280 && python3 -m venv .venv
#    .venv/bin/pip install -e ../.. && .venv/bin/pip install -r requirements.txt
# 5. .venv/bin/python main.py  # manual test first
# 6. sudo cp bme280.service /etc/systemd/system/
#    sudo sed -i "s/^User=pi$/User=$(whoami)/" /etc/systemd/system/bme280.service
#    sudo systemctl daemon-reload && sudo systemctl enable --now bme280
```

---

## Bug fixes (across commits 2–6)

| # | Where | Bug | Fix |
|---|-------|-----|-----|
| 1 | `common/mqtt.py` | `configure_logging()` no-op after `basicConfig()` | Explicit handler replacement |
| 2 | `main.py` | Bootstrap blocked JSON reconfigure; `_wait_for_connect` not signal-aware | `configure_logging(fmt="text")` bootstrap; `_stop.wait()` |
| 3 | `sensor.py` | Partial init leaked open I2C bus | `deinit()` in `except` block |
| 4 | `bme280.service` | `StartLimitIntervalSec`/`StartLimitBurst` silently ignored in `[Service]` | Moved to `[Unit]` |
| 5 | `README.md` | `pip install -e .` rejected by PEP 668 on Pi OS Bookworm | Full venv-based instructions |
| 6 | `bme280.service` | Hardcoded `/home/pi/Arkadia` paths | `${ARKADIA_ROOT}` from env file |
| 7 | `main.py` | `sensor.py` only importable when CWD = service dir | `sys.path.insert(0, Path(__file__).parent)` |
| 8 | `bme280.service` | `${ARKADIA_ROOT}` in ExecStart rejected by systemd at parse time | `ExecStart=/bin/bash -c '...'` — bash expands at runtime |
| 9 | `bme280.service` | `lgpio` creates notification pipes in CWD (`/`) which is read-only under `ProtectSystem=full` | `RuntimeDirectory=bme280` + `WorkingDirectory=/run/bme280` |

## Testing

- ✅ `ruff check .` — clean
- ✅ `python3 -m pytest tests/ -v` — 116 passed, 0 warnings
- ✅ Service running on Raspberry Pi 5 with real BME280 hardware; readings verified against a reference thermometer

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

