### PR TITLE
PR 4: SCD40 CO₂ Sensor Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ arkadia/
 │   │   ├── config.toml        # Sensor and MQTT settings
 │   │   ├── bme280.service     # systemd unit file
 │   │   └── requirements.txt
-│   ├── scd40/                 # CO₂ service (pending)
+│   ├── scd40/
+│   │   ├── sensor.py          # SCD40 driver (wraps adafruit-circuitpython-scd4x)
+│   │   ├── main.py            # Polling loop + MQTT publish
+│   │   ├── config.toml        # Sensor and MQTT settings
+│   │   ├── scd40.service      # systemd unit file
+│   │   └── requirements.txt
 │   ├── audio/                 # Ambient sound service (pending)
 │   └── api/                   # REST API service (pending)
 ├── config/
@@ -210,11 +215,43 @@ mosquitto_sub -h 127.0.0.1 -t 'home/sensors/climate/bme280' -v
 
 ## Sensors
 
-| Sensor  | Interface | Topic                         | Measurements                        |
-|---------|-----------|-------------------------------|-------------------------------------|
-| BME280  | I2C       | `home/sensors/climate/bme280` | Temperature, humidity, pressure     |
-| SCD40   | I2C       | `home/sensors/air/scd40`      | CO₂                                 |
-| INMP441 | I2S       | `home/sensors/audio/inmp441`  | Ambient sound (RMS / dBFS)          |
+| Sensor  | Interface | Topic                         | Measurements                        | Status  |
+|---------|-----------|-------------------------------|-------------------------------------|---------|
+| BME280  | I2C       | `home/sensors/climate/bme280` | Temperature, humidity, pressure     | ✅ done |
+| SCD40   | I2C       | `home/sensors/air/scd40`      | CO₂, temperature, humidity          | ✅ done |
+| INMP441 | I2S       | `home/sensors/audio/inmp441`  | Ambient sound (RMS / dBFS)          | pending |
+
+### SCD40 deployment
+
+The SCD40 follows the same deployment steps as the BME280 (see above).
+Key differences:
+
+- **Fixed I2C address:** `0x62` — no SDO pin, no config needed.
+- **Measurement cycle:** The SCD40 produces a new reading every 5 seconds
+  internally.  `read()` blocks until `data_ready` is `True`; collecting 3
+  samples therefore takes ~15 seconds.
+- **Virtualenv setup:**
+  ```bash
+  cd services/scd40
+  python3 -m venv .venv
+  .venv/bin/pip install -e ../..
+  .venv/bin/pip install -r requirements.txt
+  ```
+- **Manual test:**
+  ```bash
+  .venv/bin/python main.py
+  # First reading appears after ~15 s (3 × 5 s cycles)
+  mosquitto_sub -h 127.0.0.1 -t 'home/sensors/air/scd40' -v
+  ```
+- **Systemd install:**
+  ```bash
+  sudo cp services/scd40/scd40.service /etc/systemd/system/
+  sudo sed -i "s/^User=pi$/User=$(whoami)/" /etc/systemd/system/scd40.service
+  sudo systemctl daemon-reload
+  sudo systemctl enable scd40
+  sudo systemctl start scd40
+  journalctl -u scd40 -f
+  ```
 
 ---
 

--- a/services/scd40/config.toml
+++ b/services/scd40/config.toml
@@ -1,0 +1,25 @@
+# SCD40 service configuration.
+# Global broker and logging defaults are loaded from config/global.toml.
+
+[sensor]
+# I2C bus number. On Raspberry Pi, bus 1 is the standard 40-pin header bus.
+i2c_bus = 1
+
+# The SCD40 has a single fixed I2C address: 0x62.
+i2c_address = 0x62
+
+# Number of raw samples to collect per cycle. Median is taken.
+# Each sample takes ~5 s (the SCD40's internal measurement cycle),
+# so 3 samples = ~15 s of collection time per cycle.
+sample_count = 3
+
+# Time between successive publish cycles (seconds).
+# The collection of 3 samples takes ~15 s, so an interval of 60 s
+# leaves ~45 s of sleep time between cycles.
+interval_seconds = 60
+
+[mqtt]
+topic = "home/sensors/air/scd40"
+client_id = "scd40-service"
+qos = 1
+retain = true

--- a/services/scd40/main.py
+++ b/services/scd40/main.py
@@ -1,0 +1,244 @@
+"""SCD40 CO₂ sensor service.
+
+Polling loop:
+  1. Collect sample_count readings, each gated by the SCD40's 5-second
+     data_ready cycle (no explicit inter-sample sleep is needed).
+  2. Compute median of co2_ppm, temperature_c, and humidity_pct.
+  3. Build an SCD40Payload using common/models.py.
+  4. Publish retained JSON to the configured MQTT topic.
+  5. Sleep for the remainder of the interval, waking immediately on SIGTERM.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import statistics
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from common.config import load_config
+from common.i2c import I2CError
+from common.models import Diagnostics, Meta, SCD40Payload, SCD40Readings
+from common.mqtt import MQTTClient, configure_logging
+
+# Ensure sensor.py is importable regardless of the working directory.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from sensor import SCD40Sensor
+
+logger = logging.getLogger("scd40")
+
+_stop = threading.Event()
+
+
+def _handle_signal(signum: int, frame: object) -> None:
+    logger.info(
+        "Signal %d received — shutting down", signum, extra={"event": "service_shutdown"}
+    )
+    _stop.set()
+
+
+def _wait_for_connect(client: MQTTClient, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while not client.is_connected:
+        if time.monotonic() >= deadline:
+            return False
+        if _stop.is_set():
+            return False
+        _stop.wait(timeout=0.1)
+    return True
+
+
+def main() -> None:
+    # ----------------------------------------------------------------
+    # Logging bootstrap
+    # ----------------------------------------------------------------
+    configure_logging(level="INFO", fmt="text")
+
+    # ----------------------------------------------------------------
+    # Configuration
+    # ----------------------------------------------------------------
+    config_path = Path(__file__).parent / "config.toml"
+    try:
+        cfg = load_config(config_path)
+    except Exception as exc:
+        logger.critical("Failed to load config from %s: %s", config_path, exc)
+        sys.exit(1)
+
+    configure_logging(
+        level=cfg["logging"]["level"],
+        fmt=cfg["logging"]["format"],
+    )
+
+    logger.info("SCD40 service starting", extra={"event": "service_started"})
+    logger.info("Config loaded from %s", config_path, extra={"event": "config_loaded"})
+
+    # ----------------------------------------------------------------
+    # Signal handling
+    # ----------------------------------------------------------------
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    # ----------------------------------------------------------------
+    # MQTT
+    # ----------------------------------------------------------------
+    broker = cfg["broker"]
+    mqtt_cfg = cfg["mqtt"]
+
+    client = MQTTClient(
+        client_id=mqtt_cfg["client_id"],
+        broker_host=broker["host"],
+        broker_port=broker["port"],
+        keepalive=broker["keepalive"],
+    )
+
+    try:
+        client.connect()
+    except Exception as exc:
+        logger.critical(
+            "Cannot reach MQTT broker at %s:%d: %s",
+            broker["host"],
+            broker["port"],
+            exc,
+        )
+        sys.exit(1)
+
+    client.loop_start()
+
+    if not _wait_for_connect(client):
+        logger.critical(
+            "Timed out waiting for MQTT connection to %s:%d",
+            broker["host"],
+            broker["port"],
+        )
+        client.loop_stop()
+        sys.exit(1)
+
+    # ----------------------------------------------------------------
+    # Hardware
+    # ----------------------------------------------------------------
+    sensor_cfg = cfg["sensor"]
+    sensor = SCD40Sensor(
+        bus=sensor_cfg.get("i2c_bus", 1),
+        address=sensor_cfg["i2c_address"],
+    )
+
+    try:
+        sensor.open()
+    except I2CError as exc:
+        logger.critical("Sensor init failed: %s", exc, extra={"event": "sensor_error"})
+        client.loop_stop()
+        sys.exit(1)
+
+    # ----------------------------------------------------------------
+    # Poll loop
+    # ----------------------------------------------------------------
+    sample_count: int = sensor_cfg.get("sample_count", 3)
+    interval: float = sensor_cfg.get("interval_seconds", 60)
+    topic: str = mqtt_cfg["topic"]
+    qos: int = mqtt_cfg.get("qos", 1)
+    retain: bool = mqtt_cfg.get("retain", True)
+
+    service_start = time.monotonic()
+    read_failures = 0
+
+    logger.info(
+        "Entering poll loop (interval=%.0fs, samples=%d)",
+        interval,
+        sample_count,
+        extra={"event": "poll_loop_start"},
+    )
+
+    while not _stop.is_set():
+        cycle_start = time.monotonic()
+
+        # Collect samples — each read() blocks up to ~5 s for data_ready.
+        samples: list[dict[str, float]] = []
+        for i in range(sample_count):
+            if _stop.is_set():
+                break
+            try:
+                sample = sensor.read()
+                samples.append(sample)
+                logger.debug(
+                    "Sample %d/%d: %.0f ppm CO₂  %.2f°C  %.1f%%",
+                    i + 1,
+                    sample_count,
+                    sample["co2_ppm"],
+                    sample["temperature_c"],
+                    sample["humidity_pct"],
+                    extra={"event": "sensor_read"},
+                )
+            except I2CError as exc:
+                read_failures += 1
+                logger.warning(
+                    "Sample %d/%d failed: %s", i + 1, sample_count, exc,
+                    extra={"event": "sensor_error"},
+                )
+
+        if not samples:
+            logger.error(
+                "All %d samples failed; skipping cycle", sample_count,
+                extra={"event": "sensor_error"},
+            )
+            _stop.wait(timeout=interval)
+            continue
+
+        # Compute medians.
+        co2_ppm = statistics.median(s["co2_ppm"] for s in samples)
+        temperature_c = statistics.median(s["temperature_c"] for s in samples)
+        humidity_pct = statistics.median(s["humidity_pct"] for s in samples)
+
+        logger.info(
+            "Reading: %.0f ppm CO₂  %.2f°C  %.1f%%  (%d/%d samples)",
+            co2_ppm,
+            temperature_c,
+            humidity_pct,
+            len(samples),
+            sample_count,
+            extra={"event": "sensor_read"},
+        )
+
+        payload = SCD40Payload(
+            sensor_id="scd40",
+            timestamp=datetime.now(tz=timezone.utc),
+            readings=SCD40Readings(
+                co2_ppm=co2_ppm,
+                temperature_c=temperature_c,
+                humidity_pct=humidity_pct,
+            ),
+            meta=Meta(sample_count=len(samples), aggregation="median"),
+            diagnostics=Diagnostics(
+                uptime_seconds=time.monotonic() - service_start,
+                read_failures=read_failures,
+            ),
+        )
+
+        try:
+            client.publish(topic, payload.model_dump_json(), qos=qos, retain=retain)
+        except RuntimeError as exc:
+            logger.error(
+                "Publish failed: %s", exc, extra={"event": "mqtt_publish_error"}
+            )
+
+        elapsed = time.monotonic() - cycle_start
+        remaining = interval - elapsed
+        if remaining > 0:
+            _stop.wait(timeout=remaining)
+
+    # ----------------------------------------------------------------
+    # Shutdown
+    # ----------------------------------------------------------------
+    logger.info("Stopping poll loop", extra={"event": "service_shutdown"})
+    sensor.close()
+    client.loop_stop()
+    client.disconnect()
+    logger.info("SCD40 service stopped", extra={"event": "service_stopped"})
+
+
+if __name__ == "__main__":
+    main()

--- a/services/scd40/requirements.txt
+++ b/services/scd40/requirements.txt
@@ -1,0 +1,4 @@
+# Hardware abstraction layer for CircuitPython on Raspberry Pi
+adafruit-blinka
+# SCD40 CO2 / temperature / humidity sensor driver
+adafruit-circuitpython-scd4x

--- a/services/scd40/scd40.service
+++ b/services/scd40/scd40.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=Arkadia SCD40 CO₂ Sensor Service
+Documentation=https://github.com/malonge/Arkadia
+After=mosquitto.service
+Requires=mosquitto.service
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+
+# Change 'pi' to your actual username.
+User=pi
+Group=i2c
+
+# /etc/home-monitor.env must define ARKADIA_ROOT.
+EnvironmentFile=/etc/home-monitor.env
+
+# /bin/bash resolves at parse time; ${ARKADIA_ROOT} is expanded by bash
+# at runtime from the environment loaded via EnvironmentFile.
+ExecStart=/bin/bash -c \
+  'exec "${ARKADIA_ROOT}/services/scd40/.venv/bin/python" \
+        "${ARKADIA_ROOT}/services/scd40/main.py"'
+
+Restart=on-failure
+RestartSec=5
+# 3 samples × up to 5 s each + overhead = allow up to 30 s for clean shutdown.
+TimeoutStopSec=30
+
+# lgpio (adafruit-blinka on Pi 5) creates notification pipes (.lgd-nfy*)
+# in the working directory.  RuntimeDirectory creates /run/scd40 owned by
+# the service user; WorkingDirectory sets the CWD there so lgpio has a
+# writable location.
+RuntimeDirectory=scd40
+WorkingDirectory=/run/scd40
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=scd40
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/services/scd40/sensor.py
+++ b/services/scd40/sensor.py
@@ -1,0 +1,124 @@
+"""SCD40 sensor driver — wraps adafruit-circuitpython-scd4x."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from common.i2c import I2CBase, I2CError
+
+logger = logging.getLogger(__name__)
+
+# The SCD40 produces a new measurement every 5 seconds.  Allow up to this
+# many seconds for data_ready to become True before giving up.
+_DATA_READY_TIMEOUT = 10.0
+
+
+class SCD40Sensor(I2CBase):
+    """Read CO₂, temperature, and humidity from an SCD40 over I2C.
+
+    The SCD40 operates on a fixed 5-second internal measurement cycle.
+    :meth:`read` blocks until a fresh measurement is available
+    (``data_ready == True``), which may take up to 5 seconds.
+
+    Call :meth:`open` at startup for fail-fast hardware initialisation.
+    Hardware is otherwise initialised lazily on the first :meth:`read` call.
+
+    Example::
+
+        sensor = SCD40Sensor()
+        sensor.open()
+        data = sensor.read()   # blocks up to 5 s for first measurement
+        # {"co2_ppm": 412.0, "temperature_c": 22.1, "humidity_pct": 48.3}
+    """
+
+    # The SCD40 has a single fixed I2C address.
+    _FIXED_ADDRESS = 0x62
+
+    def __init__(self, bus: int = 1, *, address: int = 0x62) -> None:
+        super().__init__(bus=bus, address=address)
+        self._scd4x = None
+
+    # ------------------------------------------------------------------
+    # Hardware lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        """Explicitly initialise hardware.  Raises :class:`~common.i2c.I2CError` on failure."""
+        self._init_hardware()
+
+    def _init_hardware(self) -> None:
+        """Open the I2C bus, initialise the SCD4X device, and start periodic measurement."""
+        try:
+            import board  # type: ignore[import-untyped]
+            import busio  # type: ignore[import-untyped]
+            import adafruit_scd4x  # type: ignore[import-untyped]
+
+            self._i2c = busio.I2C(board.SCL, board.SDA)
+            self._scd4x = adafruit_scd4x.SCD4X(self._i2c)
+            self._scd4x.start_periodic_measurement()
+            logger.info(
+                "SCD40 ready at I2C address 0x%02X (bus %d); periodic measurement started",
+                self._address,
+                self._bus,
+                extra={"event": "i2c_bus_open"},
+            )
+        except I2CError:
+            raise
+        except Exception as exc:
+            if self._i2c is not None:
+                try:
+                    self._i2c.deinit()
+                except Exception:
+                    pass
+                self._i2c = None
+            raise I2CError(
+                f"Failed to initialise SCD40 at 0x{self._address:02X} on bus {self._bus}: {exc}"
+            ) from exc
+
+    def close(self) -> None:
+        """Stop periodic measurement and release hardware resources."""
+        if self._scd4x is not None:
+            try:
+                self._scd4x.stop_periodic_measurement()
+            except Exception:
+                logger.exception("Error stopping SCD40 measurement", extra={"event": "sensor_error"})
+            self._scd4x = None
+        super().close()
+
+    # ------------------------------------------------------------------
+    # Sensor reading
+    # ------------------------------------------------------------------
+
+    def read(self) -> dict[str, float]:
+        """Wait for the next SCD40 measurement and return it.
+
+        Blocks until ``data_ready`` is ``True`` (up to ~5 s per cycle).
+
+        Returns a dict with keys ``co2_ppm``, ``temperature_c``, and
+        ``humidity_pct``.
+
+        Raises :class:`~common.i2c.I2CError` if data does not become
+        available within the timeout or on any hardware failure.
+        """
+        if self._scd4x is None:
+            self._init_hardware()
+
+        try:
+            deadline = time.monotonic() + _DATA_READY_TIMEOUT
+            while not self._scd4x.data_ready:
+                if time.monotonic() >= deadline:
+                    raise I2CError(
+                        f"SCD40 data_ready timeout after {_DATA_READY_TIMEOUT:.0f}s"
+                    )
+                time.sleep(0.1)
+
+            return {
+                "co2_ppm": float(self._scd4x.CO2),
+                "temperature_c": float(self._scd4x.temperature),
+                "humidity_pct": float(self._scd4x.relative_humidity),
+            }
+        except I2CError:
+            raise
+        except Exception as exc:
+            raise I2CError(f"SCD40 read failed: {exc}") from exc

--- a/tests/test_bme280.py
+++ b/tests/test_bme280.py
@@ -25,8 +25,30 @@ from pydantic import ValidationError
 # ---------------------------------------------------------------------------
 
 SERVICE_DIR = Path(__file__).resolve().parent.parent / "services" / "bme280"
-if str(SERVICE_DIR) not in sys.path:
-    sys.path.insert(0, str(SERVICE_DIR))
+
+_OTHER_SERVICE_DIRS = [
+    Path(__file__).resolve().parent.parent / "services" / "scd40",
+]
+
+
+def _activate_service_path() -> None:
+    """Ensure SERVICE_DIR is the active service directory on sys.path.
+
+    Removes any other service directories that also contain a sensor.py so
+    that 'from sensor import ...' always resolves to this service's module.
+    """
+    for d in _OTHER_SERVICE_DIRS:
+        try:
+            sys.path.remove(str(d))
+        except ValueError:
+            pass
+    if sys.path[:1] != [str(SERVICE_DIR)]:
+        try:
+            sys.path.remove(str(SERVICE_DIR))
+        except ValueError:
+            pass
+        sys.path.insert(0, str(SERVICE_DIR))
+    sys.modules.pop("sensor", None)
 
 
 # ---------------------------------------------------------------------------
@@ -94,6 +116,9 @@ def _remove_fakes():
 # ---------------------------------------------------------------------------
 
 class TestBME280SensorConstruction:
+    def setup_method(self):
+        _activate_service_path()
+
     def test_default_address(self):
         from sensor import BME280Sensor
         s = BME280Sensor(address=0x76)
@@ -127,10 +152,8 @@ class TestBME280SensorConstruction:
 
 class TestBME280SensorRead:
     def setup_method(self):
+        _activate_service_path()
         _remove_fakes()
-        # Re-import sensor fresh so module-level state is clean.
-        if "sensor" in sys.modules:
-            del sys.modules["sensor"]
 
     def teardown_method(self):
         _remove_fakes()

--- a/tests/test_scd40.py
+++ b/tests/test_scd40.py
@@ -1,0 +1,335 @@
+"""Unit tests for the SCD40 sensor service — no hardware required."""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from pydantic import ValidationError
+
+SERVICE_DIR = Path(__file__).resolve().parent.parent / "services" / "scd40"
+
+_OTHER_SERVICE_DIRS = [
+    Path(__file__).resolve().parent.parent / "services" / "bme280",
+]
+
+
+def _activate_service_path() -> None:
+    """Ensure SERVICE_DIR is the active service directory on sys.path."""
+    for d in _OTHER_SERVICE_DIRS:
+        try:
+            sys.path.remove(str(d))
+        except ValueError:
+            pass
+    if sys.path[:1] != [str(SERVICE_DIR)]:
+        try:
+            sys.path.remove(str(SERVICE_DIR))
+        except ValueError:
+            pass
+        sys.path.insert(0, str(SERVICE_DIR))
+    sys.modules.pop("sensor", None)
+
+
+# ---------------------------------------------------------------------------
+# Fake hardware helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_scd4x(co2=415.0, temperature=22.1, humidity=48.3, data_ready=True):
+    """Return a fake adafruit_scd4x module and a pre-configured device mock."""
+    fake_device = MagicMock()
+    fake_device.CO2 = co2
+    fake_device.temperature = temperature
+    fake_device.relative_humidity = humidity
+    # data_ready is a property — configure it via PropertyMock on the type.
+    type(fake_device).data_ready = PropertyMock(return_value=data_ready)
+
+    fake_cls = MagicMock(return_value=fake_device)
+    fake_mod = types.ModuleType("adafruit_scd4x")
+    fake_mod.SCD4X = fake_cls
+    return fake_mod, fake_device
+
+
+def _make_fake_board_busio():
+    fake_board = types.ModuleType("board")
+    fake_board.SCL = MagicMock(name="SCL")
+    fake_board.SDA = MagicMock(name="SDA")
+    fake_i2c = MagicMock(name="I2CInstance")
+    fake_busio = types.ModuleType("busio")
+    fake_busio.I2C = MagicMock(return_value=fake_i2c)
+    return fake_board, fake_busio, fake_i2c
+
+
+def _inject_fakes(co2=415.0, temperature=22.1, humidity=48.3, data_ready=True):
+    fake_board, fake_busio, fake_i2c = _make_fake_board_busio()
+    fake_mod, fake_device = _make_fake_scd4x(co2, temperature, humidity, data_ready)
+    sys.modules.update({
+        "board": fake_board,
+        "busio": fake_busio,
+        "adafruit_scd4x": fake_mod,
+    })
+    return fake_device, fake_busio, fake_i2c
+
+
+def _remove_fakes():
+    for mod in ("board", "busio", "adafruit_scd4x"):
+        sys.modules.pop(mod, None)
+
+
+# ---------------------------------------------------------------------------
+# SCD40Sensor construction
+# ---------------------------------------------------------------------------
+
+class TestSCD40SensorConstruction:
+    def setup_method(self):
+        _activate_service_path()
+
+    def test_default_address(self):
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        assert s._address == 0x62
+        assert s._bus == 1
+
+    def test_custom_bus(self):
+        from sensor import SCD40Sensor
+        s = SCD40Sensor(bus=0, address=0x62)
+        assert s._bus == 0
+
+    def test_invalid_address_raises(self):
+        from sensor import SCD40Sensor
+        from common.i2c import I2CError
+        with pytest.raises(I2CError):
+            SCD40Sensor(address=0x00)
+
+    def test_no_hardware_on_construction(self):
+        _remove_fakes()
+        if "sensor" in sys.modules:
+            del sys.modules["sensor"]
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        assert s._scd4x is None
+
+    def test_address_keyword_only(self):
+        from sensor import SCD40Sensor
+        with pytest.raises(TypeError):
+            SCD40Sensor(1, 0x62)
+
+
+# ---------------------------------------------------------------------------
+# SCD40Sensor read
+# ---------------------------------------------------------------------------
+
+class TestSCD40SensorRead:
+    def setup_method(self):
+        _activate_service_path()
+        _remove_fakes()
+
+    def teardown_method(self):
+        _remove_fakes()
+        sys.modules.pop("sensor", None)
+
+    def test_read_returns_expected_keys(self):
+        _inject_fakes()
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        data = s.read()
+        assert set(data.keys()) == {"co2_ppm", "temperature_c", "humidity_pct"}
+
+    def test_read_returns_correct_values(self):
+        _inject_fakes(co2=412.0, temperature=21.5, humidity=50.0)
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        data = s.read()
+        assert data["co2_ppm"] == pytest.approx(412.0)
+        assert data["temperature_c"] == pytest.approx(21.5)
+        assert data["humidity_pct"] == pytest.approx(50.0)
+
+    def test_read_values_are_floats(self):
+        _inject_fakes(co2=412, temperature=21, humidity=50)
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        data = s.read()
+        assert isinstance(data["co2_ppm"], float)
+        assert isinstance(data["temperature_c"], float)
+        assert isinstance(data["humidity_pct"], float)
+
+    def test_open_inits_hardware(self):
+        _, fake_busio, _ = _inject_fakes()
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        assert s._scd4x is None
+        s.open()
+        assert s._scd4x is not None
+        assert fake_busio.I2C.call_count == 1
+
+    def test_read_starts_periodic_measurement(self):
+        fake_device, _, _ = _inject_fakes()
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        s.read()
+        fake_device.start_periodic_measurement.assert_called_once()
+
+    def test_close_stops_measurement(self):
+        fake_device, _, _ = _inject_fakes()
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        s.open()
+        s.close()
+        fake_device.stop_periodic_measurement.assert_called_once()
+        assert s._scd4x is None
+
+    def test_data_ready_timeout_raises_i2c_error(self):
+        """If data_ready never becomes True, read() raises I2CError."""
+        _inject_fakes(data_ready=False)
+        from sensor import SCD40Sensor
+        from common.i2c import I2CError
+        import sensor as sensor_mod
+        # Shorten the timeout for the test.
+        original = sensor_mod._DATA_READY_TIMEOUT
+        sensor_mod._DATA_READY_TIMEOUT = 0.2
+        try:
+            s = SCD40Sensor()
+            s.open()
+            with pytest.raises(I2CError, match="data_ready timeout"):
+                s.read()
+        finally:
+            sensor_mod._DATA_READY_TIMEOUT = original
+
+    def test_partial_init_failure_cleans_up_i2c(self):
+        """If SCD4X() raises after the I2C bus opened, self._i2c must be cleaned up."""
+        fake_board, fake_busio, fake_i2c = _make_fake_board_busio()
+        fail_mod = types.ModuleType("adafruit_scd4x")
+        fail_mod.SCD4X = MagicMock(side_effect=RuntimeError("no device"))
+        sys.modules.update({
+            "board": fake_board,
+            "busio": fake_busio,
+            "adafruit_scd4x": fail_mod,
+        })
+        from sensor import SCD40Sensor
+        from common.i2c import I2CError
+        s = SCD40Sensor()
+        with pytest.raises(I2CError):
+            s._init_hardware()
+        assert s._i2c is None
+        assert fake_i2c.deinit.call_count == 1
+
+    def test_read_hardware_error_raises_i2c_error(self):
+        _inject_fakes()
+        from sensor import SCD40Sensor
+        from common.i2c import I2CError
+        s = SCD40Sensor()
+        s.open()
+        type(s._scd4x).CO2 = PropertyMock(side_effect=OSError("bus error"))
+        with pytest.raises(I2CError, match="SCD40 read failed"):
+            s.read()
+
+
+# ---------------------------------------------------------------------------
+# Payload model validation
+# ---------------------------------------------------------------------------
+
+class TestSCD40PayloadBuilding:
+    def _make_payload(self, co2=415.0, temperature=22.1, humidity=48.3):
+        from common.models import SCD40Payload, SCD40Readings, Diagnostics, Meta
+        return SCD40Payload(
+            sensor_id="scd40",
+            timestamp=datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc),
+            readings=SCD40Readings(
+                co2_ppm=co2,
+                temperature_c=temperature,
+                humidity_pct=humidity,
+            ),
+            meta=Meta(sample_count=3, aggregation="median"),
+            diagnostics=Diagnostics(uptime_seconds=60.0, read_failures=0),
+        )
+
+    def test_valid_payload(self):
+        p = self._make_payload()
+        assert p.sensor_id == "scd40"
+        assert p.readings.co2_ppm == 415.0
+
+    def test_json_roundtrip(self):
+        from common.models import SCD40Payload
+        p = self._make_payload()
+        restored = SCD40Payload.model_validate_json(p.model_dump_json())
+        assert restored.readings.co2_ppm == pytest.approx(415.0)
+        assert restored.readings.temperature_c == pytest.approx(22.1)
+
+    def test_negative_co2_rejected(self):
+        with pytest.raises(ValidationError):
+            self._make_payload(co2=-1.0)
+
+    def test_humidity_out_of_range(self):
+        with pytest.raises(ValidationError):
+            self._make_payload(humidity=101.0)
+
+    def test_schema_version(self):
+        p = self._make_payload()
+        data = json.loads(p.model_dump_json())
+        assert data["schema_version"] == 1
+
+    def test_config_topic(self):
+        import tomllib
+        with (SERVICE_DIR / "config.toml").open("rb") as fh:
+            cfg = tomllib.load(fh)
+        assert cfg["mqtt"]["topic"] == "home/sensors/air/scd40"
+        assert cfg["mqtt"]["retain"] is True
+        assert cfg["mqtt"]["qos"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Median aggregation
+# ---------------------------------------------------------------------------
+
+class TestMedianAggregation:
+    def test_median_of_three(self):
+        samples = [
+            {"co2_ppm": 410.0, "temperature_c": 21.0, "humidity_pct": 48.0},
+            {"co2_ppm": 415.0, "temperature_c": 21.5, "humidity_pct": 49.0},
+            {"co2_ppm": 420.0, "temperature_c": 22.0, "humidity_pct": 50.0},
+        ]
+        assert statistics.median(s["co2_ppm"] for s in samples) == pytest.approx(415.0)
+        assert statistics.median(s["temperature_c"] for s in samples) == pytest.approx(21.5)
+
+    def test_median_with_outlier(self):
+        samples = [
+            {"co2_ppm": 410.0, "temperature_c": 21.0, "humidity_pct": 48.0},
+            {"co2_ppm": 415.0, "temperature_c": 21.5, "humidity_pct": 49.0},
+            {"co2_ppm": 9999.0, "temperature_c": 99.0, "humidity_pct": 99.0},
+        ]
+        assert statistics.median(s["co2_ppm"] for s in samples) == pytest.approx(415.0)
+
+    def test_single_surviving_sample(self):
+        samples = [{"co2_ppm": 412.0, "temperature_c": 22.0, "humidity_pct": 50.0}]
+        assert statistics.median(s["co2_ppm"] for s in samples) == pytest.approx(412.0)
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestSCD40Config:
+    def test_config_loads(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["sensor"]["i2c_address"] == 0x62
+        assert cfg["sensor"]["sample_count"] == 3
+        assert cfg["sensor"]["interval_seconds"] == 60
+        assert cfg["mqtt"]["topic"] == "home/sensors/air/scd40"
+
+    def test_global_defaults_merged(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["broker"]["host"] == "localhost"
+        assert cfg["broker"]["port"] == 1883
+
+    def test_i2c_address_valid(self):
+        from common.i2c import I2CBase
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        I2CBase._validate_address(cfg["sensor"]["i2c_address"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR 4** from `docs/dev-plan.md`: the SCD40 CO₂ sensor service, following the identical pattern established in PR 3 (BME280). Depends on PR 1, PR 2, PR 3 (all merged).

---

## Key difference from BME280

The SCD40 has a **fixed 5-second internal measurement cycle**. Unlike the BME280 (which can be read on demand), `read()` must wait for `data_ready == True` before accessing values. This means:
- Each `read()` call blocks up to ~5 s
- Collecting 3 samples takes ~15 s of wall time
- No explicit `sample_interval_seconds` config is needed — the sensor's own cycle gates sampling
- `TimeoutStopSec=30` in the service file (vs 15 for BME280) to accommodate worst-case collection

---

## Files

### `services/scd40/sensor.py`
`SCD40Sensor(I2CBase)` — fixed address `0x62`. `_init_hardware()` creates the `SCD4X` device and calls `start_periodic_measurement()`. `read()` polls `data_ready` (up to `_DATA_READY_TIMEOUT = 10 s`), then reads `co2_ppm`, `temperature_c`, `humidity_pct`. `close()` calls `stop_periodic_measurement()` before releasing the bus. Partial init failure cleans up `self._i2c` (same fix as BME280).

### `services/scd40/main.py`
Identical structure to `bme280/main.py`. `sys.path.insert` for sensor.py import, `threading.Event(_stop)` for SIGTERM, JSON logging via `configure_logging`.

### `services/scd40/config.toml`
`i2c_address=0x62`, `sample_count=3`, `interval_seconds=60`, topic `home/sensors/air/scd40`, QoS 1, `retain=true`.

### `services/scd40/scd40.service`
All fixes from BME280 applied: `bash -c` ExecStart, `RuntimeDirectory=scd40`, `WorkingDirectory=/run/scd40`, `StartLimitIntervalSec`/`Burst` in `[Unit]`, `TimeoutStopSec=30`.

### `services/scd40/requirements.txt`
`adafruit-blinka`, `adafruit-circuitpython-scd4x`

---

## Deploying on Raspberry Pi

```bash
cd services/scd40
python3 -m venv .venv
.venv/bin/pip install -e ../..
.venv/bin/pip install -r requirements.txt

# Manual test — first reading appears after ~15 s
.venv/bin/python main.py
mosquitto_sub -h 127.0.0.1 -t 'home/sensors/air/scd40' -v

# systemd
sudo cp scd40.service /etc/systemd/system/
sudo sed -i "s/^User=pi$/User=$(whoami)/" /etc/systemd/system/scd40.service
sudo systemctl daemon-reload
sudo systemctl enable scd40
sudo systemctl start scd40
journalctl -u scd40 -f
```

---

## Testing

- ✅ `ruff check .` — clean
- ✅ `python3 -m pytest tests/ -q` — **142 passed**, 0 warnings (26 new SCD40 tests)
- Also fixed `test_bme280.py`/`test_scd40.py` sys.path collision: each sensor test class now calls `_activate_service_path()` in `setup_method` to ensure the correct `sensor.py` is imported regardless of test collection order

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffb76465-abd3-4695-a62d-06f92714aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

