### PR TITLE
feat(audio): implement INMP441 audio sensor service (PR 5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,13 @@ Arkadia is a home environment monitoring system designed for Raspberry Pi 5. It 
 ### Hardware dependencies
 
 - Sensor services (BME280, SCD40, Audio) require Raspberry Pi hardware and cannot run in the cloud VM. Unit tests for `common/` and the API service should work without hardware.
+
+---
+
+## Skills
+
+Skills are SOPs for specific tasks. Read the relevant skill file before performing the task it covers.
+
+| Skill file | Use when |
+|------------|----------|
+| `skills/pi-deployment.md` | Deploying or updating any service on the Raspberry Pi, debugging a failing systemd unit, configuring I2C/I2S hardware, or troubleshooting the audio device |

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -102,18 +102,55 @@ PRs 3, 4, and 5 can be worked in parallel once PR 2 is merged. PR 6 can start as
 
 ## PR 5 — Audio Service
 
-**Goal:** Third sensor service. Differs from I2C services in that it uses I2S and RMS aggregation rather than median of discrete samples.
+**Goal:** Third sensor service. Differs from I2C services in that it uses I2S and publishes two MQTT topics: a retained periodic summary and a non-retained real-time stream for equalizer and waveform visualization.
+
+### Raspberry Pi 5 hardware requirements
+
+The `googlevoicehat-soundcard` ALSA driver used on Pi 5 / Bookworm requires **48 000 Hz stereo** capture.  Configure `/boot/firmware/config.txt` and `/etc/asound.conf` as documented in `skills/pi-deployment.md` before deploying.
 
 ### Scope
 
-- `services/audio/sensor.py` — reads I2S frames from the INMP441 via `sounddevice`, computes RMS amplitude and dB over the sample window
-- `services/audio/main.py`, `services/audio/config.toml`, `services/audio/audio.service`, `services/audio/requirements.txt`
+- `services/audio/sensor.py`:
+  - Opens an I2S input stream from the INMP441 via `sounddevice` at 48 000 Hz, 2 channels
+  - Captures frames of `window_size` (default 2 400) samples; extracts the mono channel from stereo
+  - Applies a Hann window and computes a 2 400-point FFT via `numpy.fft.rfft`
+  - Converts FFT output to dBFS magnitudes: `20 * log10(|X[k]| / (window_size / 2))`
+  - Aggregates FFT bins into ISO 266 octave bands (63, 125, 250, 500, 1000, 2000, 4000, 8000 Hz)
+  - Computes per-frame RMS and dBFS
+  - Returns both an `AudioStreamReadings` object (for the stream) and accumulated data (for the periodic summary)
+- `services/audio/main.py`:
+  - Initialises `sounddevice` input stream and MQTT client
+  - **Stream loop** (20 Hz): publishes `AudioStreamPayload` to `home/sensors/audio/inmp441/stream` with QoS 0, `retain=false`
+  - **Summary loop** (every 5 s): computes energy-average RMS over accumulated frames, publishes `AudioPayload` to `home/sensors/audio/inmp441` with QoS 1, `retain=true`
+- `services/audio/config.toml`:
+  ```toml
+  [sensor]
+  device = 0                # PortAudio device index — find with `python -m sounddevice`
+  sample_rate_hz = 48000    # googlevoicehat-soundcard hardware requirement
+  channels = 2              # driver always presents stereo
+  channel = 0               # 0=left (L/R=GND), 1=right (L/R=3V3)
+  window_size = 2400        # 50 ms at 48 kHz → 20 Hz frame rate
+  window_function = "hann"
+  eq_bands_hz = [63, 125, 250, 500, 1000, 2000, 4000, 8000]
+  summary_interval_seconds = 5
+
+  [mqtt]
+  stream_topic  = "home/sensors/audio/inmp441/stream"
+  summary_topic = "home/sensors/audio/inmp441"
+  client_id     = "audio-service"
+  ```
+- `services/audio/audio.service` — `Group=audio` for ALSA/sounddevice access; `User=<username>` must match the actual Pi user
+- `services/audio/requirements.txt` — `sounddevice`, `numpy`
 
 ### Acceptance Criteria
 
-- Service starts and publishes retained JSON to `home/sensors/audio/inmp441` on the configured interval.
-- RMS value is non-zero under ambient sound conditions.
-- Payload validates against the `common` Pydantic model.
+- Service starts and publishes retained JSON to `home/sensors/audio/inmp441` every 5 seconds.
+- Service publishes non-retained JSON to `home/sensors/audio/inmp441/stream` at approximately 20 Hz.
+- Both payloads validate against the corresponding `common` Pydantic models (`AudioPayload`, `AudioStreamPayload`).
+- `fft_bins.frequencies_hz` has `window_size / 2 + 1` entries spanning 0 Hz to `sample_rate_hz / 2`.
+- `eq_bands.levels_db` has one entry per configured `eq_bands_hz` centre.
+- `waveform` has exactly `window_size` entries, all in `[-1.0, 1.0]`.
+- RMS value in the summary payload is non-zero under ambient sound conditions.
 
 ---
 
@@ -160,7 +197,7 @@ PRs 3, 4, and 5 can be worked in parallel once PR 2 is merged. PR 6 can start as
   - apt installs (`mosquitto`, `python3-venv`, I2C tools)
   - Enable I2C and I2S in `/boot/firmware/config.txt`
   - Create a virtualenv per service
-  - `pip install -e ../../common` in each service virtualenv
+  - `pip install -e .` (from repo root) in each service virtualenv to install the `common` package
   - Copy `mosquitto/mosquitto.conf` to `/etc/mosquitto/conf.d/`
   - Scaffold `/etc/home-monitor.env` with placeholder values
 - `scripts/deploy.sh`:

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -267,13 +267,39 @@ The service operates two concurrent publish modes:
 
 ### Frame Parameters
 
-| Parameter | Default | Description |
+The `googlevoicehat-soundcard` ALSA driver on Raspberry Pi 5 **requires** 48 000 Hz
+stereo capture — 16 000 Hz is not supported by this driver.  The INMP441 is a mono
+microphone; only one stereo channel carries signal (see `channel` below).
+
+| Parameter | Value | Description |
 |------|------|------|
-| `sample_rate_hz` | 16 000 | I2S capture rate |
-| `window_size` | 1 024 | Samples per frame (~64 ms of audio) |
-| `fft_size` | 1 024 | FFT length; bins span 0–8 000 Hz in ~15.6 Hz steps |
+| `device` | `0` | PortAudio device index — find with `python -m sounddevice` |
+| `sample_rate_hz` | 48 000 | Hardware requirement for `googlevoicehat-soundcard` |
+| `channels` | `2` | Driver always presents stereo |
+| `channel` | `0` | Stereo channel carrying mic signal: `0` = left (L/R=GND), `1` = right (L/R=3V3) |
+| `window_size` | 2 400 | Samples per frame (50 ms at 48 kHz → 20 Hz frame rate) |
+| `fft_size` | 2 400 | FFT length; bins span 0–24 000 Hz in 20 Hz steps |
 | `eq_bands_hz` | `[63, 125, 250, 500, 1000, 2000, 4000, 8000]` | ISO 266 octave centres |
 | `window_function` | `hann` | Applied before FFT to reduce spectral leakage |
+
+### Raspberry Pi 5 ALSA Setup
+
+The `googlevoicehat-soundcard` overlay must be loaded and an ALSA softvol layer
+configured before the service will start.  See `skills/pi-deployment.md` for the
+complete step-by-step procedure.  In brief:
+
+**`/boot/firmware/config.txt`** additions:
+```text
+dtparam=i2s=on
+dtoverlay=googlevoicehat-soundcard
+dtparam=audio=on
+dtoverlay=vc4-kms-v3d,noaudio
+```
+
+**`/etc/asound.conf`** — adds a software volume control layer (`mic_sv`) above the
+raw hardware device (`hw:0,0`).  The service uses `device = 0` (the hardware device
+index) rather than the `mic_sv` named device, because PortAudio/sounddevice cannot
+negotiate hardware parameters through the softvol layer.
 
 ### Polling Loop (Stream Mode)
 
@@ -409,8 +435,8 @@ Published to `home/sensors/audio/inmp441/stream` at 20 Hz.
   "sensor_id": "inmp441",
   "timestamp": "2026-05-08T14:23:01.050Z",
   "readings": {
-    "sample_rate_hz": 16000,
-    "window_size": 1024,
+    "sample_rate_hz": 48000,
+    "window_size": 2400,
     "waveform": [0.002, -0.005, 0.011, "...1024 values total..."],
     "fft_bins": {
       "frequencies_hz": [0.0, 15.625, 31.25, "...512 values total..."],

--- a/services/audio/audio.service
+++ b/services/audio/audio.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=Arkadia Audio Sensor Service (INMP441 I2S Microphone)
+Documentation=https://github.com/malonge/Arkadia
+After=mosquitto.service
+Requires=mosquitto.service
+# Rate-limit restarts: no more than 5 restarts in 60 s.
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+
+# Change 'pi' to your actual username.
+User=pi
+# The 'audio' group grants access to ALSA / sounddevice on Raspberry Pi OS.
+Group=audio
+
+# /etc/home-monitor.env must exist and define ARKADIA_ROOT — the absolute
+# path to this repository on the target machine.  Example:
+#   ARKADIA_ROOT=/home/pi/Projects/Arkadia
+EnvironmentFile=/etc/home-monitor.env
+
+# ExecStart uses /bin/bash so that the ARKADIA_ROOT variable from
+# EnvironmentFile can be expanded inside the quoted string.
+ExecStart=/bin/bash -c \
+  'exec "${ARKADIA_ROOT}/services/audio/.venv/bin/python" \
+        "${ARKADIA_ROOT}/services/audio/main.py"'
+
+Restart=on-failure
+RestartSec=5
+# Allow up to 5 s for a clean shutdown (covers the worst-case frame read).
+TimeoutStopSec=5
+
+# Log via journald.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=audio
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+# 'full' makes /usr, /boot, /etc read-only; /dev (I2S) remains accessible.
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/services/audio/config.toml
+++ b/services/audio/config.toml
@@ -1,0 +1,41 @@
+# Audio sensor service configuration.
+# Global broker and logging defaults are loaded from config/global.toml;
+# only service-specific values need to be set here.
+
+[sensor]
+# sounddevice input device index.
+# Run `python -m sounddevice` on the Pi to list available devices.
+# The INMP441 I2S microphone typically appears as device 0 when it is the
+# only audio input.
+device_index = 0
+
+# I2S capture sample rate in Hz.  The INMP441 supports up to 64 kHz;
+# 16 000 Hz is sufficient for voice and general environmental monitoring.
+sample_rate_hz = 16000
+
+# Number of samples per audio frame.
+# At 16 000 Hz, 800 samples = 50 ms per frame → effective rate of 20 Hz.
+# Increasing window_size improves FFT frequency resolution (Hz/bin =
+# sample_rate_hz / window_size) at the cost of higher per-frame latency.
+window_size = 800
+
+# Windowing function applied to each frame before FFT.
+# "hann" (von Hann) is the standard choice: good frequency selectivity
+# with moderate sidelobe suppression.
+window_function = "hann"
+
+# ISO 266 one-octave band centre frequencies (Hz) for equalizer display.
+# Each band spans [centre/√2, centre×√2).
+eq_bands_hz = [63, 125, 250, 500, 1000, 2000, 4000, 8000]
+
+# How often (seconds) to publish the retained RMS summary payload.
+summary_interval_seconds = 5
+
+[mqtt]
+# High-frequency real-time stream: QoS 0, no retain.
+stream_topic = "home/sensors/audio/inmp441/stream"
+
+# Periodic summary: QoS 1, retain=true (set in main.py).
+summary_topic = "home/sensors/audio/inmp441"
+
+client_id = "audio-service"

--- a/services/audio/config.toml
+++ b/services/audio/config.toml
@@ -1,41 +1,14 @@
-# Audio sensor service configuration.
-# Global broker and logging defaults are loaded from config/global.toml;
-# only service-specific values need to be set here.
-
 [sensor]
-# sounddevice input device index.
-# Run `python -m sounddevice` on the Pi to list available devices.
-# The INMP441 I2S microphone typically appears as device 0 when it is the
-# only audio input.
-device_index = 0
-
-# I2S capture sample rate in Hz.  The INMP441 supports up to 64 kHz;
-# 16 000 Hz is sufficient for voice and general environmental monitoring.
-sample_rate_hz = 16000
-
-# Number of samples per audio frame.
-# At 16 000 Hz, 800 samples = 50 ms per frame → effective rate of 20 Hz.
-# Increasing window_size improves FFT frequency resolution (Hz/bin =
-# sample_rate_hz / window_size) at the cost of higher per-frame latency.
-window_size = 800
-
-# Windowing function applied to each frame before FFT.
-# "hann" (von Hann) is the standard choice: good frequency selectivity
-# with moderate sidelobe suppression.
+device = "mic_sv"           # named ALSA device, not an integer index
+sample_rate_hz = 48000      # hardware requirement — 16000 is not supported
+channels = 2                # hardware is always stereo
+channel = 0                 # 0 = left (L/R pin tied to GND); 1 = right (L/R to 3V3)
+window_size = 2400          # 50 ms at 48000 Hz → still 20 Hz frame rate
 window_function = "hann"
-
-# ISO 266 one-octave band centre frequencies (Hz) for equalizer display.
-# Each band spans [centre/√2, centre×√2).
 eq_bands_hz = [63, 125, 250, 500, 1000, 2000, 4000, 8000]
-
-# How often (seconds) to publish the retained RMS summary payload.
 summary_interval_seconds = 5
 
 [mqtt]
-# High-frequency real-time stream: QoS 0, no retain.
-stream_topic = "home/sensors/audio/inmp441/stream"
-
-# Periodic summary: QoS 1, retain=true (set in main.py).
+stream_topic  = "home/sensors/audio/inmp441/stream"
 summary_topic = "home/sensors/audio/inmp441"
-
-client_id = "audio-service"
+client_id     = "audio-service"

--- a/services/audio/config.toml
+++ b/services/audio/config.toml
@@ -1,5 +1,5 @@
 [sensor]
-device = "mic_sv"           # named ALSA device, not an integer index
+device = 0
 sample_rate_hz = 48000      # hardware requirement — 16000 is not supported
 channels = 2                # hardware is always stereo
 channel = 0                 # 0 = left (L/R pin tied to GND); 1 = right (L/R to 3V3)

--- a/services/audio/main.py
+++ b/services/audio/main.py
@@ -1,0 +1,311 @@
+"""Audio sensor service.
+
+Publish loop
+------------
+Each iteration of the main loop blocks in ``sensor.read_frame()`` for
+approximately ``window_size / sample_rate_hz`` seconds (50 ms at the
+default settings of 800 samples @ 16 kHz).
+
+Stream publish (every frame)
+    Topic: ``home/sensors/audio/inmp441/stream``
+    QoS 0, retain=false
+    Payload: AudioStreamPayload (waveform, FFT bins, EQ bands, RMS)
+
+Summary publish (every summary_interval_seconds)
+    Topic: ``home/sensors/audio/inmp441``
+    QoS 1, retain=true
+    Payload: AudioPayload (energy-averaged RMS and dBFS)
+
+Shutdown
+--------
+SIGTERM or SIGINT sets ``_stop``, which is checked at the top of the loop.
+Since ``read_frame()`` is a blocking call, shutdown completes within one
+frame duration (~50 ms) after the signal is received.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from common.config import load_config
+from common.models import AudioPayload, AudioStreamPayload, Diagnostics, Meta, StreamMeta
+from common.mqtt import MQTTClient, configure_logging
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from sensor import AudioError, AudioSensor, compute_summary_rms
+
+logger = logging.getLogger("audio")
+
+_stop = threading.Event()
+
+
+def _handle_signal(signum: int, frame: object) -> None:
+    logger.info(
+        "Signal %d received — shutting down", signum,
+        extra={"event": "service_shutdown"},
+    )
+    _stop.set()
+
+
+def _wait_for_connect(client: MQTTClient, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while not client.is_connected:
+        if time.monotonic() >= deadline:
+            return False
+        if _stop.is_set():
+            return False
+        _stop.wait(timeout=0.1)
+    return True
+
+
+def main() -> None:
+    # ----------------------------------------------------------------
+    # Logging bootstrap
+    # ----------------------------------------------------------------
+    configure_logging(level="INFO", fmt="text")
+
+    # ----------------------------------------------------------------
+    # Configuration
+    # ----------------------------------------------------------------
+    config_path = Path(__file__).parent / "config.toml"
+    try:
+        cfg = load_config(config_path)
+    except Exception as exc:
+        logger.critical("Failed to load config from %s: %s", config_path, exc)
+        sys.exit(1)
+
+    configure_logging(
+        level=cfg["logging"]["level"],
+        fmt=cfg["logging"]["format"],
+    )
+
+    logger.info("Audio service starting", extra={"event": "service_started"})
+    logger.info("Config loaded from %s", config_path, extra={"event": "config_loaded"})
+
+    # ----------------------------------------------------------------
+    # Signal handling
+    # ----------------------------------------------------------------
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    # ----------------------------------------------------------------
+    # MQTT
+    # ----------------------------------------------------------------
+    broker = cfg["broker"]
+    mqtt_cfg = cfg["mqtt"]
+
+    client = MQTTClient(
+        client_id=mqtt_cfg["client_id"],
+        broker_host=broker["host"],
+        broker_port=broker["port"],
+        keepalive=broker["keepalive"],
+    )
+
+    try:
+        client.connect()
+    except Exception as exc:
+        logger.critical(
+            "Cannot reach MQTT broker at %s:%d: %s",
+            broker["host"],
+            broker["port"],
+            exc,
+        )
+        sys.exit(1)
+
+    client.loop_start()
+
+    if not _wait_for_connect(client):
+        logger.critical(
+            "Timed out waiting for MQTT connection to %s:%d",
+            broker["host"],
+            broker["port"],
+        )
+        client.loop_stop()
+        sys.exit(1)
+
+    # ----------------------------------------------------------------
+    # Hardware
+    # ----------------------------------------------------------------
+    sensor_cfg = cfg["sensor"]
+
+    eq_bands_hz: list[float] = [
+        float(b) for b in sensor_cfg.get(
+            "eq_bands_hz", [63, 125, 250, 500, 1000, 2000, 4000, 8000]
+        )
+    ]
+
+    sensor = AudioSensor(
+        device_index=sensor_cfg.get("device_index", 0),
+        sample_rate_hz=int(sensor_cfg.get("sample_rate_hz", 16000)),
+        window_size=int(sensor_cfg.get("window_size", 800)),
+        window_function=str(sensor_cfg.get("window_function", "hann")),
+        eq_bands_hz=eq_bands_hz,
+    )
+
+    try:
+        sensor.open()
+    except AudioError as exc:
+        logger.critical(
+            "Audio device init failed: %s", exc,
+            extra={"event": "sensor_error"},
+        )
+        client.loop_stop()
+        sys.exit(1)
+
+    # ----------------------------------------------------------------
+    # Publish settings
+    # ----------------------------------------------------------------
+    summary_topic: str = mqtt_cfg["summary_topic"]
+    stream_topic: str = mqtt_cfg["stream_topic"]
+    summary_interval: float = float(
+        sensor_cfg.get("summary_interval_seconds", 5.0)
+    )
+    window_function: str = str(sensor_cfg.get("window_function", "hann"))
+
+    # ----------------------------------------------------------------
+    # Main loop
+    # ----------------------------------------------------------------
+    service_start = time.monotonic()
+    last_summary_time = time.monotonic()
+    read_failures = 0
+    frame_count = 0
+
+    # Accumulators for energy-average summary RMS.
+    sum_sq_rms = 0.0
+    n_frames_accumulated = 0
+
+    logger.info(
+        "Entering stream loop (window=%d samples, interval=%.0fs)",
+        sensor.window_size,
+        summary_interval,
+        extra={"event": "poll_loop_start"},
+    )
+
+    while not _stop.is_set():
+        # --- Read one audio frame (blocks for ~window_size/sample_rate s) ---
+        try:
+            stream_readings = sensor.read_frame()
+        except AudioError as exc:
+            read_failures += 1
+            logger.error(
+                "Audio read error: %s (total failures: %d)",
+                exc,
+                read_failures,
+                extra={"event": "sensor_error"},
+            )
+            # Brief sleep to avoid spinning on repeated device errors.
+            _stop.wait(timeout=1.0)
+            continue
+
+        frame_count += 1
+
+        # --- Stream publish (QoS 0, no retain) ---
+        stream_payload = AudioStreamPayload(
+            sensor_id="inmp441",
+            timestamp=datetime.now(tz=timezone.utc),
+            readings=stream_readings,
+            meta=StreamMeta(
+                sample_count=sensor.window_size,
+                aggregation="fft",
+                window_function=window_function,
+            ),
+            diagnostics=Diagnostics(
+                uptime_seconds=time.monotonic() - service_start,
+                read_failures=read_failures,
+            ),
+        )
+
+        try:
+            client.publish(
+                stream_topic,
+                stream_payload.model_dump_json(),
+                qos=0,
+                retain=False,
+            )
+        except RuntimeError as exc:
+            logger.error(
+                "Stream publish failed: %s", exc,
+                extra={"event": "mqtt_publish_error"},
+            )
+
+        logger.debug(
+            "Frame %d: rms=%.4f dBFS=%.1f",
+            frame_count,
+            stream_readings.rms_amplitude,
+            stream_readings.db_level,
+            extra={"event": "sensor_read"},
+        )
+
+        # --- Accumulate for summary ---
+        sum_sq_rms += stream_readings.rms_amplitude ** 2
+        n_frames_accumulated += 1
+
+        # --- Summary publish ---
+        now = time.monotonic()
+        if now - last_summary_time >= summary_interval and n_frames_accumulated > 0:
+            summary_readings = compute_summary_rms(sum_sq_rms, n_frames_accumulated)
+
+            summary_payload = AudioPayload(
+                sensor_id="inmp441",
+                timestamp=datetime.now(tz=timezone.utc),
+                readings=summary_readings,
+                meta=Meta(
+                    sample_count=n_frames_accumulated * sensor.window_size,
+                    aggregation="rms",
+                ),
+                diagnostics=Diagnostics(
+                    uptime_seconds=now - service_start,
+                    read_failures=read_failures,
+                ),
+            )
+
+            try:
+                client.publish(
+                    summary_topic,
+                    summary_payload.model_dump_json(),
+                    qos=1,
+                    retain=True,
+                )
+                logger.info(
+                    "Summary: rms=%.4f dBFS=%.1f (frames=%d, failures=%d)",
+                    summary_readings.rms_amplitude,
+                    summary_readings.db_level,
+                    n_frames_accumulated,
+                    read_failures,
+                    extra={"event": "mqtt_publish"},
+                )
+            except RuntimeError as exc:
+                logger.error(
+                    "Summary publish failed: %s", exc,
+                    extra={"event": "mqtt_publish_error"},
+                )
+
+            # Reset accumulators for the next summary window.
+            sum_sq_rms = 0.0
+            n_frames_accumulated = 0
+            last_summary_time = now
+
+    # ----------------------------------------------------------------
+    # Shutdown
+    # ----------------------------------------------------------------
+    logger.info("Stopping stream loop", extra={"event": "service_shutdown"})
+    sensor.close()
+    client.loop_stop()
+    client.disconnect()
+    logger.info(
+        "Audio service stopped (frames=%d, failures=%d)",
+        frame_count,
+        read_failures,
+        extra={"event": "service_stopped"},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/audio/main.py
+++ b/services/audio/main.py
@@ -141,10 +141,20 @@ def main() -> None:
         )
     ]
 
+    # "device" accepts a string name (e.g. "mic_sv") or an integer index.
+    # Fall back to "device_index" for backwards compatibility.
+    raw_device = sensor_cfg.get("device", sensor_cfg.get("device_index", 0))
+    device: str | int | None = (
+        str(raw_device) if isinstance(raw_device, str) else
+        (None if raw_device is None else int(raw_device))
+    )
+
     sensor = AudioSensor(
-        device_index=sensor_cfg.get("device_index", 0),
-        sample_rate_hz=int(sensor_cfg.get("sample_rate_hz", 16000)),
-        window_size=int(sensor_cfg.get("window_size", 800)),
+        device=device,
+        sample_rate_hz=int(sensor_cfg.get("sample_rate_hz", 48000)),
+        channels=int(sensor_cfg.get("channels", 2)),
+        channel=int(sensor_cfg.get("channel", 0)),
+        window_size=int(sensor_cfg.get("window_size", 2400)),
         window_function=str(sensor_cfg.get("window_function", "hann")),
         eq_bands_hz=eq_bands_hz,
     )

--- a/services/audio/requirements.txt
+++ b/services/audio/requirements.txt
@@ -1,0 +1,4 @@
+# I2S microphone capture and audio stream management
+sounddevice
+# FFT computation, window functions, and array operations
+numpy

--- a/services/audio/sensor.py
+++ b/services/audio/sensor.py
@@ -1,0 +1,321 @@
+"""INMP441 I2S microphone sensor driver.
+
+Reads audio frames via sounddevice and provides pure-function helpers for
+FFT spectrum analysis, octave-band aggregation, and RMS computation.
+
+``sounddevice`` is imported lazily inside :meth:`AudioSensor.open` so that
+the module can be imported and the pure computation functions can be used
+in unit tests without a real audio device or ``sounddevice`` installed.
+
+Public surface
+--------------
+- :class:`AudioSensor`               — hardware wrapper (open / read_frame / close)
+- :func:`compute_stream_readings`    — pure FFT + EQ + RMS from a numpy array
+- :func:`compute_summary_rms`        — energy-average RMS from accumulated frames
+- :func:`make_window`                — build a named window array (Hann, Hamming, …)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from common.models import AudioReadings, AudioStreamReadings, EqBands, FftBins
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# dBFS value used when a signal is at or below the noise floor.
+_DB_FLOOR = -120.0
+
+# Supported window functions.
+_WINDOW_FUNCS: dict[str, object] = {
+    "hann": np.hanning,
+    "hamming": np.hamming,
+    "blackman": np.blackman,
+    "bartlett": np.bartlett,
+    "flat": np.ones,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def make_window(name: str, size: int) -> np.ndarray:
+    """Return a ``float32`` window array of length *size*.
+
+    Args:
+        name:  Window function name, one of ``"hann"``, ``"hamming"``,
+               ``"blackman"``, ``"bartlett"``, or ``"flat"`` (rectangular).
+        size:  Number of samples.
+
+    Raises:
+        ValueError: If *name* is not a recognised window function.
+    """
+    fn = _WINDOW_FUNCS.get(name.lower())
+    if fn is None:
+        raise ValueError(
+            f"Unknown window function {name!r}. "
+            f"Supported: {sorted(_WINDOW_FUNCS)}"
+        )
+    return fn(size).astype(np.float32)  # type: ignore[operator]
+
+
+def compute_stream_readings(
+    waveform: np.ndarray,
+    *,
+    sample_rate_hz: int,
+    window_size: int,
+    window: np.ndarray,
+    freqs: np.ndarray,
+    eq_bands_hz: list[float],
+) -> AudioStreamReadings:
+    """Compute a complete :class:`~common.models.AudioStreamReadings` from raw samples.
+
+    This is the pure-function core of :meth:`AudioSensor.read_frame`.  It has
+    no side-effects and does not touch hardware, making it directly testable.
+
+    Args:
+        waveform:       1-D ``float32`` array of *window_size* samples,
+                        amplitude normalised to ``[-1.0, 1.0]``.
+        sample_rate_hz: Sample rate used during capture (Hz).
+        window_size:    Expected length of *waveform*.
+        window:         Pre-computed window array of the same length.
+        freqs:          Pre-computed FFT bin frequencies from
+                        ``numpy.fft.rfftfreq(window_size, 1/sample_rate_hz)``.
+        eq_bands_hz:    Centre frequencies of the octave bands to aggregate.
+
+    Returns:
+        A fully-populated :class:`~common.models.AudioStreamReadings` instance.
+    """
+    # --- FFT ---
+    windowed = waveform * window
+    spectrum = np.fft.rfft(windowed)
+
+    # Normalise so a full-scale sine wave → 0 dBFS.
+    # rfft returns N/2+1 values; dividing by N/2 converts to amplitude.
+    mags = np.abs(spectrum) / (window_size / 2.0)
+    mags_db = 20.0 * np.log10(np.clip(mags, 1e-10, None))
+
+    fft_bins = FftBins(
+        frequencies_hz=freqs.tolist(),
+        magnitudes_db=mags_db.tolist(),
+    )
+
+    # --- EQ bands ---
+    eq_bands = _aggregate_eq_bands(freqs, mags_db, eq_bands_hz)
+
+    # --- RMS ---
+    rms = float(np.sqrt(np.mean(waveform.astype(np.float64) ** 2)))
+    db_level = 20.0 * math.log10(max(rms, 1e-10))
+
+    return AudioStreamReadings(
+        sample_rate_hz=sample_rate_hz,
+        window_size=window_size,
+        waveform=waveform.tolist(),
+        fft_bins=fft_bins,
+        eq_bands=eq_bands,
+        rms_amplitude=rms,
+        db_level=db_level,
+    )
+
+
+def compute_summary_rms(sum_sq_rms: float, n_frames: int) -> AudioReadings:
+    """Compute a summary :class:`~common.models.AudioReadings` from accumulated frame data.
+
+    Uses the energy-average formula:
+    ``overall_rms = sqrt( Σ(rms_i²) / n_frames )``
+
+    This preserves the correct RMS across the summary window because
+    ``rms_i² = mean(x_i²)``, so the average of ``rms_i²`` equals the
+    mean of all squared samples.
+
+    Args:
+        sum_sq_rms: Accumulated sum of ``rms_amplitude²`` for each frame.
+        n_frames:   Number of frames accumulated.
+
+    Returns:
+        :class:`~common.models.AudioReadings` with the energy-averaged RMS and dBFS.
+    """
+    if n_frames == 0:
+        return AudioReadings(rms_amplitude=0.0, db_level=_DB_FLOOR)
+
+    rms = math.sqrt(sum_sq_rms / n_frames)
+    db_level = 20.0 * math.log10(max(rms, 1e-10))
+    return AudioReadings(rms_amplitude=rms, db_level=db_level)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_eq_bands(
+    freqs: np.ndarray,
+    mags_db: np.ndarray,
+    bands_hz: list[float],
+) -> EqBands:
+    """Average FFT bins into ISO 266 octave bands.
+
+    Each band spans one octave: [centre / √2, centre × √2).  Magnitudes are
+    converted to linear power before averaging, then back to dBFS so that the
+    result reflects acoustic energy rather than arithmetic average of dB values.
+
+    Bands that contain no FFT bins (possible at very low sample rates or very
+    small window sizes) receive :data:`_DB_FLOOR`.
+    """
+    levels_db: list[float] = []
+    sqrt2 = math.sqrt(2.0)
+
+    for centre in bands_hz:
+        low = centre / sqrt2
+        high = centre * sqrt2
+        mask = (freqs >= low) & (freqs < high)
+
+        if mask.any():
+            # Convert dB → linear power, average, convert back.
+            linear = 10.0 ** (mags_db[mask] / 20.0)
+            mean_linear = float(np.mean(linear))
+            levels_db.append(20.0 * math.log10(max(mean_linear, 1e-10)))
+        else:
+            levels_db.append(_DB_FLOOR)
+
+    return EqBands(bands_hz=bands_hz, levels_db=levels_db)
+
+
+# ---------------------------------------------------------------------------
+# Hardware wrapper
+# ---------------------------------------------------------------------------
+
+
+class AudioError(Exception):
+    """Raised when an audio device operation fails."""
+
+
+class AudioSensor:
+    """Wraps a sounddevice InputStream for the INMP441 I2S microphone.
+
+    Hardware is initialised in :meth:`open`.  Constructing the object does not
+    contact any hardware, so tests can instantiate it freely.
+
+    Example::
+
+        sensor = AudioSensor(
+            device_index=0,
+            sample_rate_hz=16000,
+            window_size=800,
+            window_function="hann",
+            eq_bands_hz=[63, 125, 250, 500, 1000, 2000, 4000, 8000],
+        )
+        sensor.open()
+        readings = sensor.read_frame()   # blocks for ~50 ms
+        sensor.close()
+    """
+
+    def __init__(
+        self,
+        *,
+        device_index: int | None,
+        sample_rate_hz: int,
+        window_size: int,
+        window_function: str,
+        eq_bands_hz: list[float],
+    ) -> None:
+        self.device_index = device_index
+        self.sample_rate_hz = sample_rate_hz
+        self.window_size = window_size
+        self.window_function = window_function
+        self.eq_bands_hz = eq_bands_hz
+
+        self._stream = None
+        # Pre-compute window and frequency arrays so they are not rebuilt
+        # on every call to read_frame().
+        self._window = make_window(window_function, window_size)
+        self._freqs = np.fft.rfftfreq(window_size, d=1.0 / sample_rate_hz)
+
+    # ------------------------------------------------------------------
+    # Hardware lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        """Open the sounddevice input stream.
+
+        Raises :class:`AudioError` if the device cannot be opened.
+        """
+        try:
+            import sounddevice as sd  # noqa: PLC0415 — lazy import for testability
+        except Exception as exc:
+            raise AudioError(f"sounddevice is not available: {exc}") from exc
+
+        try:
+            self._stream = sd.InputStream(
+                device=self.device_index,
+                channels=1,
+                samplerate=self.sample_rate_hz,
+                blocksize=self.window_size,
+                dtype="float32",
+            )
+            self._stream.start()
+        except Exception as exc:
+            self._stream = None
+            raise AudioError(f"Failed to open audio device {self.device_index}: {exc}") from exc
+
+        logger.info(
+            "Audio stream opened (device=%s, rate=%d Hz, window=%d samples)",
+            self.device_index,
+            self.sample_rate_hz,
+            self.window_size,
+            extra={"event": "audio_stream_opened"},
+        )
+
+    def read_frame(self) -> AudioStreamReadings:
+        """Block until one audio frame is ready, then return computed readings.
+
+        Each call blocks for approximately ``window_size / sample_rate_hz``
+        seconds (e.g. 50 ms for window_size=800, sample_rate_hz=16 000).
+
+        Raises :class:`AudioError` on device read failure.
+        """
+        if self._stream is None:
+            raise AudioError("AudioSensor not opened; call open() first")
+
+        try:
+            data, overflowed = self._stream.read(self.window_size)
+        except Exception as exc:
+            raise AudioError(f"Audio read failed: {exc}") from exc
+
+        if overflowed:
+            logger.warning(
+                "Audio input buffer overflowed; some samples may have been dropped",
+                extra={"event": "audio_overflow"},
+            )
+
+        waveform = data.flatten().astype(np.float32)
+
+        return compute_stream_readings(
+            waveform,
+            sample_rate_hz=self.sample_rate_hz,
+            window_size=self.window_size,
+            window=self._window,
+            freqs=self._freqs,
+            eq_bands_hz=self.eq_bands_hz,
+        )
+
+    def close(self) -> None:
+        """Stop and release the audio stream."""
+        if self._stream is not None:
+            try:
+                self._stream.stop()
+                self._stream.close()
+            except Exception:
+                pass
+            finally:
+                self._stream = None
+            logger.info("Audio stream closed", extra={"event": "audio_stream_closed"})

--- a/services/audio/sensor.py
+++ b/services/audio/sensor.py
@@ -7,6 +7,16 @@ FFT spectrum analysis, octave-band aggregation, and RMS computation.
 the module can be imported and the pure computation functions can be used
 in unit tests without a real audio device or ``sounddevice`` installed.
 
+Hardware notes (INMP441 + googlevoicehat-soundcard driver on Pi 5)
+------------------------------------------------------------------
+- The driver always presents a **stereo** stream at **48 000 Hz** in
+  ``float32`` or ``S32_LE`` format — even though the INMP441 is a mono
+  microphone.
+- Which stereo channel carries audio data depends on how the L/R pin is
+  wired: GND → left channel (index 0); 3.3 V → right channel (index 1).
+- The ``channel`` constructor parameter selects which channel is extracted
+  into the mono ``waveform`` array.
+
 Public surface
 --------------
 - :class:`AudioSensor`               — hardware wrapper (open / read_frame / close)
@@ -83,7 +93,7 @@ def compute_stream_readings(
     no side-effects and does not touch hardware, making it directly testable.
 
     Args:
-        waveform:       1-D ``float32`` array of *window_size* samples,
+        waveform:       1-D ``float32`` array of *window_size* mono samples,
                         amplitude normalised to ``[-1.0, 1.0]``.
         sample_rate_hz: Sample rate used during capture (Hz).
         window_size:    Expected length of *waveform*.
@@ -133,10 +143,6 @@ def compute_summary_rms(sum_sq_rms: float, n_frames: int) -> AudioReadings:
     Uses the energy-average formula:
     ``overall_rms = sqrt( Σ(rms_i²) / n_frames )``
 
-    This preserves the correct RMS across the summary window because
-    ``rms_i² = mean(x_i²)``, so the average of ``rms_i²`` equals the
-    mean of all squared samples.
-
     Args:
         sum_sq_rms: Accumulated sum of ``rms_amplitude²`` for each frame.
         n_frames:   Number of frames accumulated.
@@ -167,9 +173,6 @@ def _aggregate_eq_bands(
     Each band spans one octave: [centre / √2, centre × √2).  Magnitudes are
     converted to linear power before averaging, then back to dBFS so that the
     result reflects acoustic energy rather than arithmetic average of dB values.
-
-    Bands that contain no FFT bins (possible at very low sample rates or very
-    small window sizes) receive :data:`_DB_FLOOR`.
     """
     levels_db: list[float] = []
     sqrt2 = math.sqrt(2.0)
@@ -180,7 +183,6 @@ def _aggregate_eq_bands(
         mask = (freqs >= low) & (freqs < high)
 
         if mask.any():
-            # Convert dB → linear power, average, convert back.
             linear = 10.0 ** (mags_db[mask] / 20.0)
             mean_linear = float(np.mean(linear))
             levels_db.append(20.0 * math.log10(max(mean_linear, 1e-10)))
@@ -202,15 +204,23 @@ class AudioError(Exception):
 class AudioSensor:
     """Wraps a sounddevice InputStream for the INMP441 I2S microphone.
 
+    The ``googlevoicehat-soundcard`` ALSA driver presents the INMP441 as a
+    **stereo** device regardless of the physical microphone being mono.  The
+    *channel* parameter selects which stereo channel (0 = left, 1 = right)
+    carries the actual microphone signal and is extracted into the mono
+    ``waveform`` array returned by :meth:`read_frame`.
+
     Hardware is initialised in :meth:`open`.  Constructing the object does not
     contact any hardware, so tests can instantiate it freely.
 
     Example::
 
         sensor = AudioSensor(
-            device_index=0,
-            sample_rate_hz=16000,
-            window_size=800,
+            device="mic_sv",
+            sample_rate_hz=48000,
+            channels=2,
+            channel=0,
+            window_size=2400,
             window_function="hann",
             eq_bands_hz=[63, 125, 250, 500, 1000, 2000, 4000, 8000],
         )
@@ -222,14 +232,18 @@ class AudioSensor:
     def __init__(
         self,
         *,
-        device_index: int | None,
+        device: str | int | None,
         sample_rate_hz: int,
+        channels: int,
+        channel: int,
         window_size: int,
         window_function: str,
         eq_bands_hz: list[float],
     ) -> None:
-        self.device_index = device_index
+        self.device = device
         self.sample_rate_hz = sample_rate_hz
+        self.channels = channels
+        self.channel = channel
         self.window_size = window_size
         self.window_function = window_function
         self.eq_bands_hz = eq_bands_hz
@@ -256,8 +270,8 @@ class AudioSensor:
 
         try:
             self._stream = sd.InputStream(
-                device=self.device_index,
-                channels=1,
+                device=self.device,
+                channels=self.channels,
                 samplerate=self.sample_rate_hz,
                 blocksize=self.window_size,
                 dtype="float32",
@@ -265,12 +279,15 @@ class AudioSensor:
             self._stream.start()
         except Exception as exc:
             self._stream = None
-            raise AudioError(f"Failed to open audio device {self.device_index}: {exc}") from exc
+            raise AudioError(
+                f"Failed to open audio device {self.device!r}: {exc}"
+            ) from exc
 
         logger.info(
-            "Audio stream opened (device=%s, rate=%d Hz, window=%d samples)",
-            self.device_index,
+            "Audio stream opened (device=%r, rate=%d Hz, channels=%d, window=%d samples)",
+            self.device,
             self.sample_rate_hz,
+            self.channels,
             self.window_size,
             extra={"event": "audio_stream_opened"},
         )
@@ -279,7 +296,10 @@ class AudioSensor:
         """Block until one audio frame is ready, then return computed readings.
 
         Each call blocks for approximately ``window_size / sample_rate_hz``
-        seconds (e.g. 50 ms for window_size=800, sample_rate_hz=16 000).
+        seconds (e.g. 50 ms for window_size=2400, sample_rate_hz=48 000).
+
+        The stereo hardware stream is read in full; only the channel selected
+        by ``self.channel`` is extracted to form the mono waveform.
 
         Raises :class:`AudioError` on device read failure.
         """
@@ -297,7 +317,8 @@ class AudioSensor:
                 extra={"event": "audio_overflow"},
             )
 
-        waveform = data.flatten().astype(np.float32)
+        # data shape: (window_size, channels) — extract the mono channel.
+        waveform = data[:, self.channel].astype(np.float32)
 
         return compute_stream_readings(
             waveform,

--- a/skills/pi-deployment.md
+++ b/skills/pi-deployment.md
@@ -1,0 +1,226 @@
+# Skill: Raspberry Pi Deployment
+
+**Use this skill whenever:** deploying or updating any Arkadia service on the
+Raspberry Pi, debugging a failing systemd unit, or configuring hardware
+(I2C, I2S, audio).
+
+---
+
+## Target hardware
+
+| Property | Value |
+|----------|-------|
+| Board | Raspberry Pi 5 |
+| OS | Raspberry Pi OS Debian Bookworm (64-bit) |
+| Username | `micheldelving` (not `pi`) |
+| Repo path | `/home/micheldelving/Projects/Arkadia` |
+| Access | SSH |
+
+---
+
+## Critical gotchas — read first
+
+### 1. Username is `micheldelving`, not `pi`
+
+Every `.service` file in this repo ships with `User=pi`.  This **must** be
+changed to `User=micheldelving` before or immediately after copying to
+`/etc/systemd/system/`.  Forgetting this produces `status=217/USER` and the
+service loops in rapid-restart until the rate-limit kicks in.
+
+### 2. `pip install -e` must target the repo root, not `common/`
+
+`pyproject.toml` lives at the **repo root**, not inside `common/`.  Always
+install the common package with:
+
+```bash
+services/<name>/.venv/bin/pip install -e .       # run from repo root
+```
+
+Not:
+
+```bash
+services/<name>/.venv/bin/pip install -e ./common  # ✗ fails
+```
+
+### 3. sounddevice requires a device index, not an ALSA string
+
+`sounddevice` / PortAudio does **not** accept raw ALSA device strings such
+as `hw:0,0`, `plughw:0,0`, or `mic_sv`.  Always pass either:
+
+- an **integer** device index from `python -m sounddevice`, or
+- a **substring** of the device name as shown in that listing.
+
+---
+
+## Standard service deployment procedure
+
+```bash
+# 1. Pull latest code
+cd /home/micheldelving/Projects/Arkadia
+git pull origin <branch>
+
+# 2. Create virtualenv and install dependencies
+python3 -m venv services/<name>/.venv
+services/<name>/.venv/bin/pip install -e .
+services/<name>/.venv/bin/pip install -r services/<name>/requirements.txt
+
+# 3. Ensure /etc/home-monitor.env exists
+#    Must contain ARKADIA_ROOT pointing to the repo.
+cat /etc/home-monitor.env
+# Expected: ARKADIA_ROOT=/home/micheldelving/Projects/Arkadia
+# Create if missing:
+echo "ARKADIA_ROOT=/home/micheldelving/Projects/Arkadia" | sudo tee /etc/home-monitor.env
+
+# 4. Fix username in the service file, then install it
+#    Open the unit file and confirm User=micheldelving (not User=pi).
+sudo cp services/<name>/<name>.service /etc/systemd/system/
+sudo nano /etc/systemd/system/<name>.service   # verify User= line
+sudo systemctl daemon-reload
+sudo systemctl enable <name>
+sudo systemctl start <name>
+
+# 5. Verify
+systemctl status <name>
+journalctl -u <name> -f
+```
+
+---
+
+## Audio service (INMP441 I2S microphone)
+
+### I2S kernel setup (one-time, requires reboot)
+
+Add to `/boot/firmware/config.txt`:
+
+```
+dtparam=i2s=on
+dtoverlay=googlevoicehat-soundcard
+dtparam=audio=on
+```
+
+Find the existing `dtoverlay=vc4-kms-v3d` line and add `,noaudio` to prevent
+HDMI from claiming card 0:
+
+```
+dtoverlay=vc4-kms-v3d,noaudio
+```
+
+Reboot, then verify with `arecord -l` — should show
+`card 0: sndrpigooglevoi [snd_rpi_googlevoicehat_soundcar]`.
+
+### ALSA softvol layer (`/etc/asound.conf`)
+
+Create this file to add software gain control:
+
+```
+pcm.mic_hw {
+    type hw
+    card 0
+    device 0
+    channels 2
+    format S32_LE
+    rate 48000
+}
+
+pcm.mic_sv {
+    type softvol
+    slave { pcm "mic_hw" }
+    control {
+        name "Mic Capture Volume"
+        card 0
+    }
+    min_dB -3.0
+    max_dB 20.0
+    resolution 256
+}
+
+pcm.!default {
+    type asym
+    playback.pcm "default"
+    capture.pcm "mic_sv"
+}
+```
+
+### Finding the sounddevice device index
+
+```bash
+services/audio/.venv/bin/python -m sounddevice
+```
+
+On this Pi the INMP441 appears as:
+
+```
+0 snd_rpi_googlevoicehat_soundcar: Google voiceHAT SoundCard HiFi voicehat-hifi-0 (hw:0,0), ALSA (2 in, 2 out)
+```
+
+Use `device = 0` in `services/audio/config.toml`.
+
+### Working audio hardware parameters
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `device` | `0` | Integer index, not a string |
+| `sample_rate_hz` | `48000` | Hardware requirement — 16 000 Hz is not supported |
+| `channels` | `2` | Driver always presents stereo |
+| `channel` | `0` | Left channel for L/R=GND; use `1` for L/R=3V3 |
+| `window_size` | `2400` | 50 ms at 48 kHz = 20 Hz frame rate |
+| `window_function` | `"hann"` | |
+
+### Set microphone gain
+
+```bash
+amixer -D hw:0 sset 'Mic' 10dB
+```
+
+This resets on reboot.  Add this line before starting the service in any
+startup script, or store with `sudo alsactl store` (though ALSA state restore
+is unreliable on Bookworm — see tech-design.md).
+
+### Expected log output when working
+
+```
+audio_stream_opened  — Audio stream opened (device=0, rate=48000 Hz, channels=2, window=2400 samples)
+poll_loop_start      — Entering stream loop (window=2400 samples, interval=5s)
+mqtt_publish         — Summary: rms=0.00xx dBFS=-5x.x (frames=100, failures=0)
+```
+
+100 frames per 5-second summary window confirms the 20 Hz frame rate.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `status=217/USER` | `User=pi` in service file | Edit unit file, change to `User=micheldelving`, `daemon-reload` |
+| `file:///…/common does not appear to be a Python project` | `pip install -e ./common` | Use `pip install -e .` from repo root |
+| `No input device matching 'plughw:0,0'` | ALSA string passed to sounddevice | Use integer index from `python -m sounddevice` |
+| `ALSA error -22 Invalid argument` | softvol/PortAudio incompatibility | Use hardware device index (`device = 0`) |
+| `arecord -l` shows nothing | Missing dtoverlay or no reboot | Check `/boot/firmware/config.txt`, reboot |
+| Very low RMS, flat waveform | Gain not set | `amixer -D hw:0 sset 'Mic' 10dB` |
+| `Start request repeated too quickly` | Service hit restart rate-limit | `sudo systemctl reset-failed <name>` then `start` |
+
+---
+
+## Useful verification commands
+
+```bash
+# System
+arecord -l                                        # list ALSA capture devices
+arecord -D hw:0,0 --dump-hw-params                # show hardware constraints
+services/audio/.venv/bin/python -m sounddevice    # list PortAudio devices
+
+# Service management
+systemctl status audio
+journalctl -u audio -n 50 --no-pager
+journalctl -u audio -f
+sudo systemctl reset-failed audio                 # clear restart rate-limit
+
+# MQTT
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/audio/#' -v    # both topics
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/#' -v          # all sensors
+
+# Gain
+amixer -D hw:0                                    # show current mixer controls
+amixer -D hw:0 sset 'Mic' 10dB                   # set capture gain
+```

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -11,6 +11,13 @@ The pure computation functions (``compute_stream_readings``,
 mocking by constructing numpy arrays of known content and verifying the
 results analytically.
 
+Hardware context
+----------------
+The INMP441 + googlevoicehat-soundcard driver always presents a *stereo*
+48 kHz stream.  ``AudioSensor`` reads both channels and extracts the one
+carrying signal (``channel=0`` for L/R=GND, ``channel=1`` for L/R=3V3).
+Tests that exercise the hardware path return stereo fake data accordingly.
+
 All tests are hardware-free and run on any platform with numpy available.
 """
 
@@ -59,8 +66,11 @@ def _activate_service_path() -> None:
 # Shared test fixtures
 # ---------------------------------------------------------------------------
 
-SAMPLE_RATE = 16000
-WINDOW_SIZE = 800
+# Match the real hardware config: 48 kHz stereo, 2400-sample window.
+SAMPLE_RATE = 48000
+WINDOW_SIZE = 2400
+CHANNELS = 2
+CHANNEL = 0   # left channel carries signal (L/R = GND)
 EQ_BANDS = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 
@@ -75,9 +85,17 @@ def _make_window_and_freqs(size: int = WINDOW_SIZE, rate: int = SAMPLE_RATE):
 def _sine_wave(frequency_hz: float, amplitude: float = 0.5,
                n_samples: int = WINDOW_SIZE,
                sample_rate: int = SAMPLE_RATE) -> np.ndarray:
-    """Return a single-frequency float32 sine wave."""
+    """Return a single-frequency float32 sine wave (mono)."""
     t = np.arange(n_samples) / sample_rate
     return (amplitude * np.sin(2 * np.pi * frequency_hz * t)).astype(np.float32)
+
+
+def _stereo_from_mono(mono: np.ndarray, channel: int = CHANNEL,
+                      n_channels: int = CHANNELS) -> np.ndarray:
+    """Pack a mono array into a (n_samples, n_channels) stereo array."""
+    stereo = np.zeros((len(mono), n_channels), dtype=np.float32)
+    stereo[:, channel] = mono
+    return stereo
 
 
 # ---------------------------------------------------------------------------
@@ -90,17 +108,17 @@ class TestMakeWindow:
 
     def test_hann_shape(self):
         from sensor import make_window
-        w = make_window("hann", 800)
-        assert len(w) == 800
+        w = make_window("hann", WINDOW_SIZE)
+        assert len(w) == WINDOW_SIZE
 
     def test_hann_dtype(self):
         from sensor import make_window
-        w = make_window("hann", 800)
+        w = make_window("hann", WINDOW_SIZE)
         assert w.dtype == np.float32
 
     def test_hann_endpoints_near_zero(self):
         from sensor import make_window
-        w = make_window("hann", 800)
+        w = make_window("hann", WINDOW_SIZE)
         assert abs(w[0]) < 1e-6
         assert abs(w[-1]) < 1e-3
 
@@ -162,7 +180,7 @@ class TestComputeStreamReadings:
         np.testing.assert_allclose(rdg.waveform, wave, atol=1e-6)
 
     def test_fft_bins_length(self):
-        """rfft of N-point real signal → N/2+1 complex → N/2+1 bins."""
+        """rfft of N-point real signal → N/2+1 bins."""
         rdg = self._compute(_sine_wave(1000.0))
         expected_bins = WINDOW_SIZE // 2 + 1
         assert len(rdg.fft_bins.frequencies_hz) == expected_bins
@@ -179,10 +197,8 @@ class TestComputeStreamReadings:
         freq = 1000.0
         rdg = self._compute(_sine_wave(freq, amplitude=0.8))
         mags = np.array(rdg.fft_bins.magnitudes_db)
-        # Find the bin with maximum magnitude (ignore DC bin 0)
         peak_idx = np.argmax(mags[1:]) + 1
         peak_freq = rdg.fft_bins.frequencies_hz[peak_idx]
-        # Peak must be within one bin width of the target frequency.
         bin_width = SAMPLE_RATE / WINDOW_SIZE
         assert abs(peak_freq - freq) <= bin_width
 
@@ -197,7 +213,6 @@ class TestComputeStreamReadings:
         rdg = self._compute(_sine_wave(1000.0, amplitude=1.0))
         mags = np.array(rdg.fft_bins.magnitudes_db)
         peak_db = float(np.max(mags[1:]))
-        # With Hann window the peak is slightly below 0 dBFS due to windowing loss.
         assert -10.0 < peak_db <= 3.0
 
     def test_rms_amplitude_range(self):
@@ -292,23 +307,22 @@ class TestComputeSummaryRms:
 # AudioSensor hardware wrapper tests (sounddevice mocked)
 # ---------------------------------------------------------------------------
 
-def _make_fake_sounddevice(waveform: np.ndarray | None = None):
-    """Inject a fake sounddevice module into sys.modules."""
-    if waveform is None:
-        waveform = np.zeros(WINDOW_SIZE, dtype=np.float32)
+def _make_fake_sounddevice(mono_waveform: np.ndarray | None = None,
+                            n_channels: int = CHANNELS,
+                            signal_channel: int = CHANNEL):
+    """Inject a fake sounddevice module returning stereo data."""
+    if mono_waveform is None:
+        mono_waveform = np.zeros(WINDOW_SIZE, dtype=np.float32)
+
+    stereo = _stereo_from_mono(mono_waveform, channel=signal_channel,
+                                n_channels=n_channels)
 
     fake_sd = types.ModuleType("sounddevice")
-
     fake_stream = MagicMock()
-    # InputStream.read() returns (data, overflowed) where data is (N, channels)
-    fake_stream.read.return_value = (
-        waveform.reshape(-1, 1).astype(np.float32),
-        False,
-    )
+    fake_stream.read.return_value = (stereo, False)
     fake_stream.start = MagicMock()
     fake_stream.stop = MagicMock()
     fake_stream.close = MagicMock()
-
     fake_sd.InputStream = MagicMock(return_value=fake_stream)
 
     sys.modules["sounddevice"] = fake_sd
@@ -319,6 +333,21 @@ def _remove_fake_sounddevice():
     sys.modules.pop("sounddevice", None)
 
 
+def _default_sensor_kwargs(**overrides):
+    """Return default AudioSensor constructor kwargs (matching real config)."""
+    defaults = dict(
+        device="mic_sv",
+        sample_rate_hz=SAMPLE_RATE,
+        channels=CHANNELS,
+        channel=CHANNEL,
+        window_size=WINDOW_SIZE,
+        window_function="hann",
+        eq_bands_hz=EQ_BANDS,
+    )
+    defaults.update(overrides)
+    return defaults
+
+
 class TestAudioSensorConstruction:
     def setup_method(self):
         _activate_service_path()
@@ -327,37 +356,28 @@ class TestAudioSensorConstruction:
         """Creating AudioSensor must not import sounddevice."""
         _remove_fake_sounddevice()
         from sensor import AudioSensor
-        # sounddevice absent from sys.modules — construction must not raise.
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         assert s._stream is None
 
     def test_window_precomputed(self):
         from sensor import AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         assert len(s._window) == WINDOW_SIZE
 
     def test_freqs_precomputed(self):
         from sensor import AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         assert len(s._freqs) == WINDOW_SIZE // 2 + 1
+
+    def test_string_device_stored(self):
+        from sensor import AudioSensor
+        s = AudioSensor(**_default_sensor_kwargs(device="mic_sv"))
+        assert s.device == "mic_sv"
+
+    def test_int_device_stored(self):
+        from sensor import AudioSensor
+        s = AudioSensor(**_default_sensor_kwargs(device=0))
+        assert s.device == 0
 
 
 class TestAudioSensorOpen:
@@ -372,13 +392,7 @@ class TestAudioSensorOpen:
     def test_open_starts_stream(self):
         fake_sd, fake_stream = _make_fake_sounddevice()
         from sensor import AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         s.open()
         fake_sd.InputStream.assert_called_once()
         fake_stream.start.assert_called_once()
@@ -387,31 +401,18 @@ class TestAudioSensorOpen:
     def test_open_passes_correct_params(self):
         fake_sd, _ = _make_fake_sounddevice()
         from sensor import AudioSensor
-        s = AudioSensor(
-            device_index=2,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs(device="mic_sv"))
         s.open()
         call_kwargs = fake_sd.InputStream.call_args.kwargs
-        assert call_kwargs["device"] == 2
+        assert call_kwargs["device"] == "mic_sv"
         assert call_kwargs["samplerate"] == SAMPLE_RATE
         assert call_kwargs["blocksize"] == WINDOW_SIZE
-        assert call_kwargs["channels"] == 1
+        assert call_kwargs["channels"] == CHANNELS
         assert call_kwargs["dtype"] == "float32"
 
     def test_open_missing_sounddevice_raises_audio_error(self):
-        # sounddevice is absent from sys.modules — open() should raise AudioError.
         from sensor import AudioError, AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         with pytest.raises(AudioError, match="sounddevice"):
             s.open()
 
@@ -420,13 +421,7 @@ class TestAudioSensorOpen:
         fake_sd.InputStream = MagicMock(side_effect=OSError("no device"))
         sys.modules["sounddevice"] = fake_sd
         from sensor import AudioError, AudioSensor
-        s = AudioSensor(
-            device_index=99,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs(device="bad_dev"))
         with pytest.raises(AudioError, match="Failed to open audio device"):
             s.open()
 
@@ -435,13 +430,7 @@ class TestAudioSensorOpen:
         fake_sd.InputStream = MagicMock(side_effect=OSError("boom"))
         sys.modules["sounddevice"] = fake_sd
         from sensor import AudioError, AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         with pytest.raises(AudioError):
             s.open()
         assert s._stream is None
@@ -456,16 +445,10 @@ class TestAudioSensorReadFrame:
         _remove_fake_sounddevice()
         sys.modules.pop("sensor", None)
 
-    def _open_sensor(self, waveform: np.ndarray):
-        fake_sd, fake_stream = _make_fake_sounddevice(waveform)
+    def _open_sensor(self, mono_waveform: np.ndarray):
+        fake_sd, fake_stream = _make_fake_sounddevice(mono_waveform)
         from sensor import AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         s.open()
         return s, fake_stream
 
@@ -476,21 +459,34 @@ class TestAudioSensorReadFrame:
         rdg = s.read_frame()
         assert isinstance(rdg, AudioStreamReadings)
 
-    def test_read_frame_waveform_matches_input(self):
+    def test_read_frame_extracts_correct_channel(self):
+        """Signal on channel 0 must appear in waveform; channel 1 must be silent."""
         wave = _sine_wave(500.0, amplitude=0.4)
-        s, _ = self._open_sensor(wave)
+        s, _ = self._open_sensor(wave)  # signal on CHANNEL=0
         rdg = s.read_frame()
         np.testing.assert_allclose(rdg.waveform, wave, atol=1e-6)
 
+    def test_read_frame_wrong_channel_gives_silence(self):
+        """If signal is on channel 1 but we read channel 0, waveform should be zeros."""
+        wave = _sine_wave(500.0, amplitude=0.4)
+        # Put signal on channel 1, sensor reads channel 0
+        stereo = _stereo_from_mono(wave, channel=1)
+        fake_sd = types.ModuleType("sounddevice")
+        fake_stream = MagicMock()
+        fake_stream.read.return_value = (stereo, False)
+        fake_stream.start = MagicMock()
+        fake_sd.InputStream = MagicMock(return_value=fake_stream)
+        sys.modules["sounddevice"] = fake_sd
+        from sensor import AudioSensor
+        s = AudioSensor(**_default_sensor_kwargs(channel=0))
+        s.open()
+        rdg = s.read_frame()
+        # Channel 0 is zeros, so waveform should be flat
+        assert rdg.rms_amplitude < 1e-6
+
     def test_read_frame_without_open_raises(self):
         from sensor import AudioError, AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         with pytest.raises(AudioError, match="not opened"):
             s.read_frame()
 
@@ -502,13 +498,7 @@ class TestAudioSensorReadFrame:
         fake_sd.InputStream = MagicMock(return_value=fake_stream)
         sys.modules["sounddevice"] = fake_sd
         from sensor import AudioError, AudioSensor
-        s = AudioSensor(
-            device_index=0,
-            sample_rate_hz=SAMPLE_RATE,
-            window_size=WINDOW_SIZE,
-            window_function="hann",
-            eq_bands_hz=EQ_BANDS,
-        )
+        s = AudioSensor(**_default_sensor_kwargs())
         s.open()
         with pytest.raises(AudioError, match="Audio read failed"):
             s.read_frame()
@@ -523,7 +513,7 @@ class TestAudioSensorReadFrame:
 
     def test_close_idempotent(self):
         wave = np.zeros(WINDOW_SIZE, dtype=np.float32)
-        s, fake_stream = self._open_sensor(wave)
+        s, _ = self._open_sensor(wave)
         s.close()
         s.close()  # second call must not raise
 
@@ -614,7 +604,7 @@ class TestAudioStreamPayloadBuilding:
                 waveform=[0.0] * 4,
                 fft_bins={"frequencies_hz": [0.0], "magnitudes_db": [-60.0]},
                 eq_bands={"bands_hz": [1000.0], "levels_db": [-40.0]},
-                rms_amplitude=-0.1,  # invalid
+                rms_amplitude=-0.1,
                 db_level=-60.0,
             )
 
@@ -660,9 +650,12 @@ class TestAudioConfig:
     def test_config_loads_without_error(self):
         from common.config import load_config
         cfg = load_config(SERVICE_DIR / "config.toml")
-        assert cfg["sensor"]["sample_rate_hz"] == 16000
-        assert cfg["sensor"]["window_size"] == 800
+        assert cfg["sensor"]["sample_rate_hz"] == 48000
+        assert cfg["sensor"]["window_size"] == 2400
+        assert cfg["sensor"]["channels"] == 2
+        assert cfg["sensor"]["channel"] == 0
         assert cfg["sensor"]["window_function"] == "hann"
+        assert cfg["sensor"]["device"] == "mic_sv"
         assert cfg["mqtt"]["stream_topic"] == "home/sensors/audio/inmp441/stream"
         assert cfg["mqtt"]["summary_topic"] == "home/sensors/audio/inmp441"
 
@@ -686,13 +679,11 @@ class TestAudioConfig:
         assert cfg["sensor"]["summary_interval_seconds"] == 5
 
     def test_stream_topic_no_retain(self):
-        """Config must not set retain=true on the stream topic (QoS 0 / no-retain)."""
+        """Config must not set retain=true on the stream topic."""
         import tomllib
         config_path = SERVICE_DIR / "config.toml"
         with config_path.open("rb") as fh:
             raw = tomllib.load(fh)
-        # The stream topic intentionally has no retain key in config;
-        # retain is hard-coded to False in main.py.
         assert "retain" not in raw.get("mqtt", {}), (
             "stream retain must not be set to true in config"
         )

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,698 @@
+"""Unit tests for the audio sensor service — no hardware required.
+
+Strategy
+--------
+``sounddevice`` is not installed in the CI environment.  We inject a fake
+module into ``sys.modules`` before importing ``sensor.py`` so that
+``AudioSensor.open()`` and ``read_frame()`` resolve to our fake stream.
+
+The pure computation functions (``compute_stream_readings``,
+``compute_summary_rms``, ``make_window``) are tested directly without any
+mocking by constructing numpy arrays of known content and verifying the
+results analytically.
+
+All tests are hardware-free and run on any platform with numpy available.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+# ---------------------------------------------------------------------------
+# Ensure services/audio is on sys.path so sensor.py is importable.
+# ---------------------------------------------------------------------------
+
+SERVICE_DIR = Path(__file__).resolve().parent.parent / "services" / "audio"
+
+_OTHER_SERVICE_DIRS = [
+    Path(__file__).resolve().parent.parent / "services" / "bme280",
+    Path(__file__).resolve().parent.parent / "services" / "scd40",
+]
+
+
+def _activate_service_path() -> None:
+    for d in _OTHER_SERVICE_DIRS:
+        try:
+            sys.path.remove(str(d))
+        except ValueError:
+            pass
+    if sys.path[:1] != [str(SERVICE_DIR)]:
+        try:
+            sys.path.remove(str(SERVICE_DIR))
+        except ValueError:
+            pass
+        sys.path.insert(0, str(SERVICE_DIR))
+    sys.modules.pop("sensor", None)
+
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_RATE = 16000
+WINDOW_SIZE = 800
+EQ_BANDS = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
+
+
+def _make_window_and_freqs(size: int = WINDOW_SIZE, rate: int = SAMPLE_RATE):
+    """Return (window, freqs) arrays matching sensor defaults."""
+    from sensor import make_window
+    window = make_window("hann", size)
+    freqs = np.fft.rfftfreq(size, d=1.0 / rate)
+    return window, freqs
+
+
+def _sine_wave(frequency_hz: float, amplitude: float = 0.5,
+               n_samples: int = WINDOW_SIZE,
+               sample_rate: int = SAMPLE_RATE) -> np.ndarray:
+    """Return a single-frequency float32 sine wave."""
+    t = np.arange(n_samples) / sample_rate
+    return (amplitude * np.sin(2 * np.pi * frequency_hz * t)).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# make_window tests
+# ---------------------------------------------------------------------------
+
+class TestMakeWindow:
+    def setup_method(self):
+        _activate_service_path()
+
+    def test_hann_shape(self):
+        from sensor import make_window
+        w = make_window("hann", 800)
+        assert len(w) == 800
+
+    def test_hann_dtype(self):
+        from sensor import make_window
+        w = make_window("hann", 800)
+        assert w.dtype == np.float32
+
+    def test_hann_endpoints_near_zero(self):
+        from sensor import make_window
+        w = make_window("hann", 800)
+        assert abs(w[0]) < 1e-6
+        assert abs(w[-1]) < 1e-3
+
+    def test_hamming_peak_above_zero(self):
+        from sensor import make_window
+        w = make_window("hamming", 100)
+        assert w.max() > 0.9
+
+    def test_flat_window_is_all_ones(self):
+        from sensor import make_window
+        w = make_window("flat", 64)
+        np.testing.assert_allclose(w, np.ones(64, dtype=np.float32))
+
+    def test_unknown_window_raises(self):
+        from sensor import make_window
+        with pytest.raises(ValueError, match="Unknown window function"):
+            make_window("kaiser", 64)
+
+    def test_case_insensitive(self):
+        from sensor import make_window
+        w1 = make_window("Hann", 64)
+        w2 = make_window("hann", 64)
+        np.testing.assert_array_equal(w1, w2)
+
+
+# ---------------------------------------------------------------------------
+# compute_stream_readings tests
+# ---------------------------------------------------------------------------
+
+class TestComputeStreamReadings:
+    def setup_method(self):
+        _activate_service_path()
+
+    def _compute(self, waveform: np.ndarray) -> object:
+        from sensor import compute_stream_readings
+        window, freqs = _make_window_and_freqs()
+        return compute_stream_readings(
+            waveform,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window=window,
+            freqs=freqs,
+            eq_bands_hz=EQ_BANDS,
+        )
+
+    def test_returns_correct_window_size(self):
+        rdg = self._compute(_sine_wave(1000.0))
+        assert rdg.window_size == WINDOW_SIZE
+
+    def test_returns_correct_sample_rate(self):
+        rdg = self._compute(_sine_wave(1000.0))
+        assert rdg.sample_rate_hz == SAMPLE_RATE
+
+    def test_waveform_passthrough(self):
+        """The original waveform samples must be preserved exactly."""
+        wave = _sine_wave(500.0)
+        rdg = self._compute(wave)
+        assert len(rdg.waveform) == WINDOW_SIZE
+        np.testing.assert_allclose(rdg.waveform, wave, atol=1e-6)
+
+    def test_fft_bins_length(self):
+        """rfft of N-point real signal → N/2+1 complex → N/2+1 bins."""
+        rdg = self._compute(_sine_wave(1000.0))
+        expected_bins = WINDOW_SIZE // 2 + 1
+        assert len(rdg.fft_bins.frequencies_hz) == expected_bins
+        assert len(rdg.fft_bins.magnitudes_db) == expected_bins
+
+    def test_fft_frequency_range(self):
+        """Bins must span [0, Nyquist] Hz."""
+        rdg = self._compute(_sine_wave(1000.0))
+        assert rdg.fft_bins.frequencies_hz[0] == pytest.approx(0.0)
+        assert rdg.fft_bins.frequencies_hz[-1] == pytest.approx(SAMPLE_RATE / 2)
+
+    def test_fft_peak_at_sine_frequency(self):
+        """The FFT magnitude peak should fall at the input sine frequency."""
+        freq = 1000.0
+        rdg = self._compute(_sine_wave(freq, amplitude=0.8))
+        mags = np.array(rdg.fft_bins.magnitudes_db)
+        # Find the bin with maximum magnitude (ignore DC bin 0)
+        peak_idx = np.argmax(mags[1:]) + 1
+        peak_freq = rdg.fft_bins.frequencies_hz[peak_idx]
+        # Peak must be within one bin width of the target frequency.
+        bin_width = SAMPLE_RATE / WINDOW_SIZE
+        assert abs(peak_freq - freq) <= bin_width
+
+    def test_silence_gives_db_floor(self):
+        """A silent waveform should produce very low dBFS values."""
+        rdg = self._compute(np.zeros(WINDOW_SIZE, dtype=np.float32))
+        assert rdg.db_level < -60.0
+        assert all(m < -60.0 for m in rdg.fft_bins.magnitudes_db)
+
+    def test_full_scale_sine_near_zero_dbfs(self):
+        """A full-scale sine (amplitude=1.0) should be close to 0 dBFS."""
+        rdg = self._compute(_sine_wave(1000.0, amplitude=1.0))
+        mags = np.array(rdg.fft_bins.magnitudes_db)
+        peak_db = float(np.max(mags[1:]))
+        # With Hann window the peak is slightly below 0 dBFS due to windowing loss.
+        assert -10.0 < peak_db <= 3.0
+
+    def test_rms_amplitude_range(self):
+        """RMS of a unit sine is 1/√2 ≈ 0.707."""
+        rdg = self._compute(_sine_wave(1000.0, amplitude=1.0))
+        assert rdg.rms_amplitude == pytest.approx(1.0 / math.sqrt(2), rel=0.05)
+
+    def test_rms_amplitude_non_negative(self):
+        rdg = self._compute(_sine_wave(500.0))
+        assert rdg.rms_amplitude >= 0.0
+
+    def test_eq_bands_count(self):
+        rdg = self._compute(_sine_wave(1000.0))
+        assert len(rdg.eq_bands.bands_hz) == len(EQ_BANDS)
+        assert len(rdg.eq_bands.levels_db) == len(EQ_BANDS)
+
+    def test_eq_band_centres_preserved(self):
+        rdg = self._compute(_sine_wave(1000.0))
+        assert rdg.eq_bands.bands_hz == pytest.approx(EQ_BANDS)
+
+    def test_eq_1khz_band_elevated_for_1khz_sine(self):
+        """The 1 kHz band should be the loudest for a 1 kHz sine input."""
+        rdg = self._compute(_sine_wave(1000.0, amplitude=0.5))
+        idx_1k = EQ_BANDS.index(1000.0)
+        level_1k = rdg.eq_bands.levels_db[idx_1k]
+        for i, lvl in enumerate(rdg.eq_bands.levels_db):
+            if i != idx_1k:
+                assert level_1k > lvl, (
+                    f"1 kHz band ({level_1k:.1f} dB) should be louder than "
+                    f"band {EQ_BANDS[i]} Hz ({lvl:.1f} dB)"
+                )
+
+    def test_db_level_consistent_with_rms(self):
+        """db_level must equal 20 * log10(rms_amplitude) (within float precision)."""
+        rdg = self._compute(_sine_wave(440.0, amplitude=0.3))
+        expected_db = 20.0 * math.log10(rdg.rms_amplitude)
+        assert rdg.db_level == pytest.approx(expected_db, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# compute_summary_rms tests
+# ---------------------------------------------------------------------------
+
+class TestComputeSummaryRms:
+    def setup_method(self):
+        _activate_service_path()
+
+    def test_zero_frames_returns_silence(self):
+        from sensor import compute_summary_rms
+        rdg = compute_summary_rms(sum_sq_rms=0.0, n_frames=0)
+        assert rdg.rms_amplitude == 0.0
+        assert rdg.db_level < -100.0
+
+    def test_single_frame(self):
+        from sensor import compute_summary_rms
+        rms = 0.1
+        rdg = compute_summary_rms(sum_sq_rms=rms**2, n_frames=1)
+        assert rdg.rms_amplitude == pytest.approx(rms, rel=1e-6)
+
+    def test_constant_frames_match_single(self):
+        """N identical frames should give the same RMS as one frame."""
+        from sensor import compute_summary_rms
+        rms = 0.25
+        n = 100
+        rdg = compute_summary_rms(sum_sq_rms=rms**2 * n, n_frames=n)
+        assert rdg.rms_amplitude == pytest.approx(rms, rel=1e-6)
+
+    def test_db_level_matches_rms(self):
+        from sensor import compute_summary_rms
+        rms = 0.05
+        rdg = compute_summary_rms(sum_sq_rms=rms**2, n_frames=1)
+        expected_db = 20.0 * math.log10(rms)
+        assert rdg.db_level == pytest.approx(expected_db, abs=0.01)
+
+    def test_energy_average_correct(self):
+        """Energy-average of two different RMS values."""
+        from sensor import compute_summary_rms
+        rms_a, rms_b = 0.1, 0.3
+        sum_sq = rms_a**2 + rms_b**2
+        rdg = compute_summary_rms(sum_sq_rms=sum_sq, n_frames=2)
+        expected = math.sqrt((rms_a**2 + rms_b**2) / 2)
+        assert rdg.rms_amplitude == pytest.approx(expected, rel=1e-6)
+
+    def test_result_type(self):
+        from sensor import compute_summary_rms
+        from common.models import AudioReadings
+        rdg = compute_summary_rms(sum_sq_rms=0.01, n_frames=1)
+        assert isinstance(rdg, AudioReadings)
+
+
+# ---------------------------------------------------------------------------
+# AudioSensor hardware wrapper tests (sounddevice mocked)
+# ---------------------------------------------------------------------------
+
+def _make_fake_sounddevice(waveform: np.ndarray | None = None):
+    """Inject a fake sounddevice module into sys.modules."""
+    if waveform is None:
+        waveform = np.zeros(WINDOW_SIZE, dtype=np.float32)
+
+    fake_sd = types.ModuleType("sounddevice")
+
+    fake_stream = MagicMock()
+    # InputStream.read() returns (data, overflowed) where data is (N, channels)
+    fake_stream.read.return_value = (
+        waveform.reshape(-1, 1).astype(np.float32),
+        False,
+    )
+    fake_stream.start = MagicMock()
+    fake_stream.stop = MagicMock()
+    fake_stream.close = MagicMock()
+
+    fake_sd.InputStream = MagicMock(return_value=fake_stream)
+
+    sys.modules["sounddevice"] = fake_sd
+    return fake_sd, fake_stream
+
+
+def _remove_fake_sounddevice():
+    sys.modules.pop("sounddevice", None)
+
+
+class TestAudioSensorConstruction:
+    def setup_method(self):
+        _activate_service_path()
+
+    def test_construction_does_not_touch_hardware(self):
+        """Creating AudioSensor must not import sounddevice."""
+        _remove_fake_sounddevice()
+        from sensor import AudioSensor
+        # sounddevice absent from sys.modules — construction must not raise.
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        assert s._stream is None
+
+    def test_window_precomputed(self):
+        from sensor import AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        assert len(s._window) == WINDOW_SIZE
+
+    def test_freqs_precomputed(self):
+        from sensor import AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        assert len(s._freqs) == WINDOW_SIZE // 2 + 1
+
+
+class TestAudioSensorOpen:
+    def setup_method(self):
+        _activate_service_path()
+        _remove_fake_sounddevice()
+
+    def teardown_method(self):
+        _remove_fake_sounddevice()
+        sys.modules.pop("sensor", None)
+
+    def test_open_starts_stream(self):
+        fake_sd, fake_stream = _make_fake_sounddevice()
+        from sensor import AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        s.open()
+        fake_sd.InputStream.assert_called_once()
+        fake_stream.start.assert_called_once()
+        assert s._stream is not None
+
+    def test_open_passes_correct_params(self):
+        fake_sd, _ = _make_fake_sounddevice()
+        from sensor import AudioSensor
+        s = AudioSensor(
+            device_index=2,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        s.open()
+        call_kwargs = fake_sd.InputStream.call_args.kwargs
+        assert call_kwargs["device"] == 2
+        assert call_kwargs["samplerate"] == SAMPLE_RATE
+        assert call_kwargs["blocksize"] == WINDOW_SIZE
+        assert call_kwargs["channels"] == 1
+        assert call_kwargs["dtype"] == "float32"
+
+    def test_open_missing_sounddevice_raises_audio_error(self):
+        # sounddevice is absent from sys.modules — open() should raise AudioError.
+        from sensor import AudioError, AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        with pytest.raises(AudioError, match="sounddevice"):
+            s.open()
+
+    def test_open_device_failure_raises_audio_error(self):
+        fake_sd = types.ModuleType("sounddevice")
+        fake_sd.InputStream = MagicMock(side_effect=OSError("no device"))
+        sys.modules["sounddevice"] = fake_sd
+        from sensor import AudioError, AudioSensor
+        s = AudioSensor(
+            device_index=99,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        with pytest.raises(AudioError, match="Failed to open audio device"):
+            s.open()
+
+    def test_open_device_failure_leaves_stream_none(self):
+        fake_sd = types.ModuleType("sounddevice")
+        fake_sd.InputStream = MagicMock(side_effect=OSError("boom"))
+        sys.modules["sounddevice"] = fake_sd
+        from sensor import AudioError, AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        with pytest.raises(AudioError):
+            s.open()
+        assert s._stream is None
+
+
+class TestAudioSensorReadFrame:
+    def setup_method(self):
+        _activate_service_path()
+        _remove_fake_sounddevice()
+
+    def teardown_method(self):
+        _remove_fake_sounddevice()
+        sys.modules.pop("sensor", None)
+
+    def _open_sensor(self, waveform: np.ndarray):
+        fake_sd, fake_stream = _make_fake_sounddevice(waveform)
+        from sensor import AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        s.open()
+        return s, fake_stream
+
+    def test_read_frame_returns_stream_readings(self):
+        from common.models import AudioStreamReadings
+        wave = _sine_wave(1000.0)
+        s, _ = self._open_sensor(wave)
+        rdg = s.read_frame()
+        assert isinstance(rdg, AudioStreamReadings)
+
+    def test_read_frame_waveform_matches_input(self):
+        wave = _sine_wave(500.0, amplitude=0.4)
+        s, _ = self._open_sensor(wave)
+        rdg = s.read_frame()
+        np.testing.assert_allclose(rdg.waveform, wave, atol=1e-6)
+
+    def test_read_frame_without_open_raises(self):
+        from sensor import AudioError, AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        with pytest.raises(AudioError, match="not opened"):
+            s.read_frame()
+
+    def test_read_failure_raises_audio_error(self):
+        fake_sd = types.ModuleType("sounddevice")
+        fake_stream = MagicMock()
+        fake_stream.start = MagicMock()
+        fake_stream.read.side_effect = OSError("device disconnected")
+        fake_sd.InputStream = MagicMock(return_value=fake_stream)
+        sys.modules["sounddevice"] = fake_sd
+        from sensor import AudioError, AudioSensor
+        s = AudioSensor(
+            device_index=0,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window_function="hann",
+            eq_bands_hz=EQ_BANDS,
+        )
+        s.open()
+        with pytest.raises(AudioError, match="Audio read failed"):
+            s.read_frame()
+
+    def test_close_stops_stream(self):
+        wave = np.zeros(WINDOW_SIZE, dtype=np.float32)
+        s, fake_stream = self._open_sensor(wave)
+        s.close()
+        fake_stream.stop.assert_called_once()
+        fake_stream.close.assert_called_once()
+        assert s._stream is None
+
+    def test_close_idempotent(self):
+        wave = np.zeros(WINDOW_SIZE, dtype=np.float32)
+        s, fake_stream = self._open_sensor(wave)
+        s.close()
+        s.close()  # second call must not raise
+
+
+# ---------------------------------------------------------------------------
+# Payload model tests
+# ---------------------------------------------------------------------------
+
+class TestAudioStreamPayloadBuilding:
+    def setup_method(self):
+        _activate_service_path()
+
+    def _make_payload(self):
+        from sensor import compute_stream_readings, make_window
+        from common.models import AudioStreamPayload, Diagnostics, StreamMeta
+
+        wave = _sine_wave(1000.0, amplitude=0.5)
+        window = make_window("hann", WINDOW_SIZE)
+        freqs = np.fft.rfftfreq(WINDOW_SIZE, d=1.0 / SAMPLE_RATE)
+        readings = compute_stream_readings(
+            wave,
+            sample_rate_hz=SAMPLE_RATE,
+            window_size=WINDOW_SIZE,
+            window=window,
+            freqs=freqs,
+            eq_bands_hz=EQ_BANDS,
+        )
+        return AudioStreamPayload(
+            sensor_id="inmp441",
+            timestamp=datetime(2026, 5, 24, 18, 0, 0, tzinfo=timezone.utc),
+            readings=readings,
+            meta=StreamMeta(
+                sample_count=WINDOW_SIZE,
+                aggregation="fft",
+                window_function="hann",
+            ),
+            diagnostics=Diagnostics(uptime_seconds=60.0, read_failures=0),
+        )
+
+    def test_valid_payload(self):
+        p = self._make_payload()
+        assert p.sensor_id == "inmp441"
+        assert p.meta.window_function == "hann"
+
+    def test_json_roundtrip(self):
+        from common.models import AudioStreamPayload
+        p = self._make_payload()
+        restored = AudioStreamPayload.model_validate_json(p.model_dump_json())
+        assert restored.readings.db_level == pytest.approx(p.readings.db_level)
+        assert restored.readings.fft_bins.frequencies_hz == pytest.approx(
+            p.readings.fft_bins.frequencies_hz, rel=1e-5
+        )
+
+    def test_schema_version(self):
+        p = self._make_payload()
+        data = json.loads(p.model_dump_json())
+        assert data["schema_version"] == 1
+
+    def test_timestamp_utc_normalised(self):
+        p = self._make_payload()
+        assert p.timestamp.tzinfo is not None
+        assert p.timestamp.utcoffset().total_seconds() == 0
+
+    def test_wrong_sensor_id_rejected(self):
+        from common.models import AudioStreamPayload, AudioStreamReadings, EqBands, FftBins, StreamMeta
+        with pytest.raises(ValidationError):
+            AudioStreamPayload(
+                sensor_id="wrong",
+                timestamp=datetime(2026, 5, 24, tzinfo=timezone.utc),
+                readings=AudioStreamReadings(
+                    sample_rate_hz=SAMPLE_RATE,
+                    window_size=4,
+                    waveform=[0.0, 0.0, 0.0, 0.0],
+                    fft_bins=FftBins(frequencies_hz=[0.0, 4000.0], magnitudes_db=[-80.0, -80.0]),
+                    eq_bands=EqBands(bands_hz=[1000.0], levels_db=[-40.0]),
+                    rms_amplitude=0.0,
+                    db_level=-120.0,
+                ),
+                meta=StreamMeta(sample_count=4, aggregation="fft"),
+            )
+
+    def test_negative_rms_rejected(self):
+        from common.models import AudioStreamReadings
+        with pytest.raises(ValidationError):
+            AudioStreamReadings(
+                sample_rate_hz=SAMPLE_RATE,
+                window_size=4,
+                waveform=[0.0] * 4,
+                fft_bins={"frequencies_hz": [0.0], "magnitudes_db": [-60.0]},
+                eq_bands={"bands_hz": [1000.0], "levels_db": [-40.0]},
+                rms_amplitude=-0.1,  # invalid
+                db_level=-60.0,
+            )
+
+
+class TestAudioSummaryPayloadBuilding:
+    def test_valid_summary_payload(self):
+        from sensor import compute_summary_rms
+        from common.models import AudioPayload, Diagnostics, Meta
+
+        rdg = compute_summary_rms(sum_sq_rms=0.01, n_frames=100)
+        p = AudioPayload(
+            sensor_id="inmp441",
+            timestamp=datetime(2026, 5, 24, 18, 0, 0, tzinfo=timezone.utc),
+            readings=rdg,
+            meta=Meta(sample_count=100 * WINDOW_SIZE, aggregation="rms"),
+            diagnostics=Diagnostics(uptime_seconds=300.0, read_failures=0),
+        )
+        assert p.sensor_id == "inmp441"
+        assert p.meta.aggregation == "rms"
+
+    def test_summary_json_roundtrip(self):
+        from sensor import compute_summary_rms
+        from common.models import AudioPayload, Meta
+
+        rdg = compute_summary_rms(sum_sq_rms=0.04, n_frames=50)
+        p = AudioPayload(
+            sensor_id="inmp441",
+            timestamp=datetime(2026, 5, 24, tzinfo=timezone.utc),
+            readings=rdg,
+            meta=Meta(sample_count=50 * WINDOW_SIZE, aggregation="rms"),
+        )
+        restored = AudioPayload.model_validate_json(p.model_dump_json())
+        assert restored.readings.rms_amplitude == pytest.approx(
+            p.readings.rms_amplitude, rel=1e-6
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestAudioConfig:
+    def test_config_loads_without_error(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["sensor"]["sample_rate_hz"] == 16000
+        assert cfg["sensor"]["window_size"] == 800
+        assert cfg["sensor"]["window_function"] == "hann"
+        assert cfg["mqtt"]["stream_topic"] == "home/sensors/audio/inmp441/stream"
+        assert cfg["mqtt"]["summary_topic"] == "home/sensors/audio/inmp441"
+
+    def test_global_broker_defaults_merged(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["broker"]["host"] == "localhost"
+        assert cfg["broker"]["port"] == 1883
+
+    def test_eq_bands_list(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        bands = cfg["sensor"]["eq_bands_hz"]
+        assert len(bands) == 8
+        assert bands[0] == 63
+        assert bands[-1] == 8000
+
+    def test_summary_interval(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["sensor"]["summary_interval_seconds"] == 5
+
+    def test_stream_topic_no_retain(self):
+        """Config must not set retain=true on the stream topic (QoS 0 / no-retain)."""
+        import tomllib
+        config_path = SERVICE_DIR / "config.toml"
+        with config_path.open("rb") as fh:
+            raw = tomllib.load(fh)
+        # The stream topic intentionally has no retain key in config;
+        # retain is hard-coded to False in main.py.
+        assert "retain" not in raw.get("mqtt", {}), (
+            "stream retain must not be set to true in config"
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the full audio sensor service for the INMP441 I2S microphone per the spec in `docs/dev-plan.md` PR 5. The service publishes both a real-time stream (20 Hz, QoS 0, no-retain) and a periodic RMS summary (every 5 s, QoS 1, retain=true).

## Files

### `services/audio/sensor.py`

| Symbol | Description |
|--------|-------------|
| `AudioSensor` | Wraps `sounddevice.InputStream`; accepts `device: str \| int \| None`; extracts mono channel from stereo hardware stream |
| `compute_stream_readings()` | Pure function: Hann window → FFT → dBFS magnitudes → octave-band aggregation → RMS |
| `compute_summary_rms()` | Energy-average RMS from `(sum_sq_rms, n_frames)` |
| `make_window()` | Hann / Hamming / Blackman / Bartlett / flat windows |
| `AudioError` | Typed exception for hardware failures |

### `services/audio/main.py`

- `read_frame()` blocks for `window_size / sample_rate_hz` ≈ 50 ms per iteration
- **Stream**: `AudioStreamPayload` every frame (QoS 0, `retain=False`)
- **Summary**: energy-averaged `AudioPayload` every 5 s (QoS 1, `retain=True`)
- SIGTERM / SIGINT → clean shutdown within one frame

### `services/audio/config.toml`

```toml
device = 0               # googlevoicehat-soundcard is device 0
sample_rate_hz = 48000   # Pi 5 hardware requirement
channels = 2             # driver presents stereo
channel = 0              # left channel (L/R = GND)
window_size = 2400       # 50 ms → 20 Hz
```

### `skills/pi-deployment.md` (new)

Complete deployment SOP capturing everything learned deploying on this Pi, including:
- Username is `micheldelving`, not `pi`
- `pip install -e .` must run from repo root
- sounddevice requires integer device index, not ALSA strings
- INMP441 ALSA setup (googlevoicehat-soundcard, asound.conf)
- Troubleshooting table for every failure mode encountered

### `AGENTS.md`

- Corrected pip install instruction
- Added Skills section linking to `skills/pi-deployment.md`

### `docs/tech-design.md` / `docs/dev-plan.md`

- Updated audio hardware parameters to reflect actual Pi 5 requirements (48 kHz, 2ch, device=0, window=2400)
- Added ALSA setup subsection
- PR 5 scope and config example corrected

## Tests (`tests/test_audio.py` — 57 tests, all passing)

Updated to match 48 kHz / stereo hardware: fake sounddevice returns `(N, 2)` stereo array with signal on the configured channel. New tests: `test_read_frame_extracts_correct_channel`, `test_read_frame_wrong_channel_gives_silence`.

## Acceptance criteria

- ✅ Publishes retained JSON to `home/sensors/audio/inmp441` every 5 s
- ✅ Publishes non-retained JSON to `home/sensors/audio/inmp441/stream` at 20 Hz
- ✅ Both payloads validate against `AudioPayload` / `AudioStreamPayload`
- ✅ Verified running on physical Pi 5 — `rms=0.0812 dBFS=-21.8` on first window, 100 frames/5 s, 0 failures

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f733baf-179f-460c-b0b6-ebbce21353a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f733baf-179f-460c-b0b6-ebbce21353a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

