### PR TITLE
feat(deploy): implement setup.sh and deploy.sh (PR 7)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# deploy.sh — Arkadia service deployment and update
+#
+# Copies systemd unit files, reloads systemd, enables all services, and
+# starts them in the correct dependency order.
+#
+# Must be run as root:  sudo bash scripts/deploy.sh
+#
+# Idempotent — safe to re-run after a code change.  Running it will restart
+# all Arkadia services so the latest code is picked up.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYSTEMD_DIR="/etc/systemd/system"
+ENV_FILE="/etc/home-monitor.env"
+
+# Ordered service list: mosquitto is a system service installed separately;
+# sensor services and api are the Arkadia-managed units.
+SENSOR_SERVICES=(bme280 scd40 audio)
+ALL_ARKADIA_SERVICES=(bme280 scd40 audio api)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+info()  { echo "[deploy] $*"; }
+warn()  { echo "[deploy] WARNING: $*" >&2; }
+die()   { echo "[deploy] ERROR: $*" >&2; exit 1; }
+
+require_root() {
+    [[ "${EUID:-$(id -u)}" -eq 0 ]] || die "This script must be run as root (sudo bash scripts/deploy.sh)."
+}
+
+detect_service_user() {
+    if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+        echo "${SUDO_USER}"
+    else
+        stat -c '%U' "${REPO_ROOT}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+preflight() {
+    [[ -f "${ENV_FILE}" ]] || die \
+        "${ENV_FILE} not found. Run scripts/setup.sh first."
+
+    local root
+    root="$(grep -E '^ARKADIA_ROOT=' "${ENV_FILE}" | cut -d= -f2- || true)"
+    [[ -n "${root}" ]] || die \
+        "ARKADIA_ROOT is not set in ${ENV_FILE}. Run scripts/setup.sh first."
+
+    if grep -q "change-me-before-starting-api" "${ENV_FILE}"; then
+        warn "MONITOR_API_KEY in ${ENV_FILE} is still the placeholder value."
+        warn "Update it before exposing the API to any clients."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Install service unit files
+# ---------------------------------------------------------------------------
+
+install_units() {
+    local service_user="$1"
+    local service
+
+    for service in "${ALL_ARKADIA_SERVICES[@]}"; do
+        local src_file
+        # Find the .service file for this service.
+        src_file="$(find "${REPO_ROOT}/services/${service}" -maxdepth 1 -name "*.service" | head -1)"
+        if [[ -z "${src_file}" ]]; then
+            warn "No .service file found for ${service} — skipping."
+            continue
+        fi
+
+        local dst_file="${SYSTEMD_DIR}/${service}.service"
+
+        info "Installing ${src_file} → ${dst_file}..."
+        install -m 644 "${src_file}" "${dst_file}"
+
+        # Replace the placeholder 'pi' username with the actual service user.
+        if grep -q "^User=pi$" "${dst_file}"; then
+            info "  Replacing User=pi with User=${service_user}..."
+            sed -i "s/^User=pi$/User=${service_user}/" "${dst_file}"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Enable services
+# ---------------------------------------------------------------------------
+
+enable_services() {
+    local service
+    info "Reloading systemd daemon..."
+    systemctl daemon-reload
+
+    for service in "${ALL_ARKADIA_SERVICES[@]}"; do
+        if [[ -f "${SYSTEMD_DIR}/${service}.service" ]]; then
+            info "Enabling ${service}.service..."
+            systemctl enable "${service}"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Start services in dependency order
+# ---------------------------------------------------------------------------
+
+start_services() {
+    # Mosquitto must be up first.
+    info "Ensuring mosquitto.service is running..."
+    systemctl restart mosquitto
+    sleep 1
+    if ! systemctl is-active --quiet mosquitto; then
+        die "mosquitto.service failed to start. Check: journalctl -u mosquitto -n 50"
+    fi
+
+    # Sensor services can start in parallel.
+    info "Starting sensor services (bme280, scd40, audio)..."
+    local service
+    for service in "${SENSOR_SERVICES[@]}"; do
+        if [[ -f "${SYSTEMD_DIR}/${service}.service" ]]; then
+            systemctl restart "${service}" || warn "${service}.service failed to restart — check logs."
+        fi
+    done
+
+    # API depends on the broker being up (already confirmed above).
+    info "Starting api.service..."
+    systemctl restart api || warn "api.service failed to restart — check logs."
+
+    # Brief pause so units have time to transition to active/failed.
+    sleep 2
+}
+
+# ---------------------------------------------------------------------------
+# Status report
+# ---------------------------------------------------------------------------
+
+print_status() {
+    info ""
+    info "Service status:"
+    local service
+    for service in mosquitto "${ALL_ARKADIA_SERVICES[@]}"; do
+        local status
+        status="$(systemctl is-active "${service}" 2>/dev/null || true)"
+        printf "  %-12s %s\n" "${service}" "${status}"
+    done
+    info ""
+    info "View logs with:  journalctl -u <service> -f"
+    info "Full status  :   systemctl status bme280 scd40 audio api"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+require_root
+SERVICE_USER="$(detect_service_user)"
+info "Repository root : ${REPO_ROOT}"
+info "Service user    : ${SERVICE_USER}"
+
+preflight
+install_units "${SERVICE_USER}"
+enable_services
+start_services
+print_status
+
+info "Deploy complete."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,67 +1,83 @@
 #!/usr/bin/env bash
-# setup.sh — Arkadia first-time system setup (partial: Mosquitto only)
+# setup.sh — Arkadia first-time system setup
 #
-# This is the partial version delivered in PR 2.  The complete script
-# (Python virtualenvs, I2C/I2S enablement, env file scaffold) is in PR 7.
+# Installs system packages, configures I2C/I2S hardware, creates per-service
+# Python virtualenvs, and scaffolds /etc/home-monitor.env.
 #
 # Must be run as root:  sudo bash scripts/setup.sh
 #
-# Idempotent — safe to re-run after a config change.
+# Idempotent — safe to re-run after a code or configuration change.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CONF_SRC="${REPO_ROOT}/mosquitto/mosquitto.conf"
-CONF_DST="/etc/mosquitto/conf.d/arkadia.conf"
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 info()  { echo "[setup] $*"; }
+warn()  { echo "[setup] WARNING: $*" >&2; }
 die()   { echo "[setup] ERROR: $*" >&2; exit 1; }
 
 require_root() {
-    [[ "${EUID:-$(id -u)}" -eq 0 ]] || die "This script must be run as root."
+    [[ "${EUID:-$(id -u)}" -eq 0 ]] || die "This script must be run as root (sudo bash scripts/setup.sh)."
+}
+
+# Return the user who invoked sudo, falling back to the owner of REPO_ROOT.
+detect_service_user() {
+    if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+        echo "${SUDO_USER}"
+    else
+        stat -c '%U' "${REPO_ROOT}"
+    fi
+}
+
+# Add a line to a file only if it is not already present.
+append_if_missing() {
+    local file="$1" line="$2"
+    if ! grep -qF "${line}" "${file}" 2>/dev/null; then
+        echo "${line}" >> "${file}"
+        info "  Added: ${line}"
+    else
+        info "  Already present: ${line}"
+    fi
 }
 
 # ---------------------------------------------------------------------------
-# Install Mosquitto
+# 1. System packages
 # ---------------------------------------------------------------------------
 
-install_mosquitto() {
+install_packages() {
     info "Updating package lists..."
     apt-get update -qq
 
-    info "Installing mosquitto and mosquitto-clients..."
-    apt-get install -y -qq mosquitto mosquitto-clients
+    info "Installing system packages..."
+    apt-get install -y -qq \
+        mosquitto \
+        mosquitto-clients \
+        python3-venv \
+        python3-dev \
+        i2c-tools \
+        libasound2-dev
 }
 
 # ---------------------------------------------------------------------------
-# Install configuration
+# 2. Mosquitto configuration
 # ---------------------------------------------------------------------------
 
-install_config() {
-    if [[ ! -f "${CONF_SRC}" ]]; then
-        die "mosquitto/mosquitto.conf not found at ${CONF_SRC}"
-    fi
+install_mosquitto_config() {
+    local src="${REPO_ROOT}/mosquitto/mosquitto.conf"
+    local dst="/etc/mosquitto/conf.d/arkadia.conf"
 
-    info "Installing ${CONF_SRC} → ${CONF_DST}..."
-    install -m 644 "${CONF_SRC}" "${CONF_DST}"
-}
+    [[ -f "${src}" ]] || die "mosquitto/mosquitto.conf not found at ${src}"
 
-# ---------------------------------------------------------------------------
-# Enable and start service
-# ---------------------------------------------------------------------------
+    info "Installing Mosquitto config → ${dst}..."
+    install -m 644 "${src}" "${dst}"
 
-enable_service() {
-    info "Enabling mosquitto.service..."
+    info "Enabling and restarting mosquitto.service..."
     systemctl enable mosquitto
-
-    info "Restarting mosquitto.service..."
     systemctl restart mosquitto
-
-    # Give the broker a moment to come up before reporting status.
     sleep 1
     if systemctl is-active --quiet mosquitto; then
         info "mosquitto.service is active."
@@ -71,15 +87,194 @@ enable_service() {
 }
 
 # ---------------------------------------------------------------------------
+# 3. I2C enablement
+# ---------------------------------------------------------------------------
+
+enable_i2c() {
+    if command -v raspi-config &>/dev/null; then
+        info "Enabling I2C via raspi-config..."
+        raspi-config nonint do_i2c 0
+    else
+        warn "raspi-config not found — skipping I2C enablement (not on a Raspberry Pi?)."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# 4. I2S / audio hardware configuration
+# ---------------------------------------------------------------------------
+
+BOOT_CONFIG="/boot/firmware/config.txt"
+
+enable_i2s() {
+    if [[ ! -f "${BOOT_CONFIG}" ]]; then
+        warn "${BOOT_CONFIG} not found — skipping I2S configuration (not on a Raspberry Pi?)."
+        return
+    fi
+
+    info "Configuring I2S in ${BOOT_CONFIG}..."
+
+    # Append vc4-kms-v3d,noaudio if the plain variant exists but noaudio is absent.
+    if grep -q "dtoverlay=vc4-kms-v3d" "${BOOT_CONFIG}" && \
+       ! grep -q "dtoverlay=vc4-kms-v3d,noaudio" "${BOOT_CONFIG}"; then
+        info "  Patching vc4-kms-v3d → vc4-kms-v3d,noaudio..."
+        sed -i 's/dtoverlay=vc4-kms-v3d$/dtoverlay=vc4-kms-v3d,noaudio/' "${BOOT_CONFIG}"
+    else
+        info "  vc4-kms-v3d,noaudio already configured."
+    fi
+
+    append_if_missing "${BOOT_CONFIG}" "dtparam=i2s=on"
+    append_if_missing "${BOOT_CONFIG}" "dtoverlay=googlevoicehat-soundcard"
+    append_if_missing "${BOOT_CONFIG}" "dtparam=audio=on"
+
+    info "I2S configuration written.  A reboot is required for changes to take effect."
+}
+
+install_asound_conf() {
+    local dst="/etc/asound.conf"
+    if [[ -f "${dst}" ]]; then
+        info "/etc/asound.conf already exists — leaving untouched."
+        return
+    fi
+
+    info "Writing ALSA softvol layer to ${dst}..."
+    cat > "${dst}" << 'EOF'
+# Arkadia — ALSA configuration for INMP441 I2S microphone
+# Provides a software volume control layer (mic_sv) over the raw hardware
+# device (mic_hw).  The audio service uses device index 0 (the hw device)
+# rather than the mic_sv named device because PortAudio/sounddevice cannot
+# negotiate hardware parameters through the softvol layer.
+
+pcm.mic_hw {
+    type hw
+    card 0
+    device 0
+    channels 2
+    format S32_LE
+    rate 48000
+}
+
+pcm.mic_sv {
+    type softvol
+    slave { pcm "mic_hw" }
+    control {
+        name "Mic Capture Volume"
+        card 0
+    }
+    min_dB -3.0
+    max_dB 20.0
+    resolution 256
+}
+
+pcm.!default {
+    type asym
+    playback.pcm "default"
+    capture.pcm "mic_sv"
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# 5. Per-service Python virtualenvs
+# ---------------------------------------------------------------------------
+
+SERVICES=(bme280 scd40 audio api)
+
+create_virtualenvs() {
+    local service user="$1"
+    for service in "${SERVICES[@]}"; do
+        local svc_dir="${REPO_ROOT}/services/${service}"
+        local venv_dir="${svc_dir}/.venv"
+        local req_file="${svc_dir}/requirements.txt"
+
+        if [[ ! -d "${svc_dir}" ]]; then
+            warn "Service directory not found: ${svc_dir} — skipping."
+            continue
+        fi
+
+        info "Setting up virtualenv for ${service}..."
+
+        if [[ ! -d "${venv_dir}" ]]; then
+            info "  Creating ${venv_dir}..."
+            python3 -m venv "${venv_dir}"
+        else
+            info "  Virtualenv already exists at ${venv_dir}."
+        fi
+
+        info "  Installing common package (pip install -e .)..."
+        "${venv_dir}/bin/pip" install --quiet -e "${REPO_ROOT}"
+
+        if [[ -f "${req_file}" ]]; then
+            info "  Installing ${service} requirements..."
+            "${venv_dir}/bin/pip" install --quiet -r "${req_file}"
+        fi
+
+        # Ensure the virtualenv is owned by the service user, not root.
+        chown -R "${user}:${user}" "${venv_dir}"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# 6. /etc/home-monitor.env scaffold
+# ---------------------------------------------------------------------------
+
+ENV_FILE="/etc/home-monitor.env"
+PLACEHOLDER_KEY="change-me-before-starting-api"
+
+scaffold_env_file() {
+    local repo_root="$1"
+
+    if [[ -f "${ENV_FILE}" ]]; then
+        # Update ARKADIA_ROOT if it differs (e.g. repo was moved).
+        local current_root
+        current_root="$(grep -E '^ARKADIA_ROOT=' "${ENV_FILE}" | cut -d= -f2- || true)"
+        if [[ "${current_root}" != "${repo_root}" ]]; then
+            info "Updating ARKADIA_ROOT in ${ENV_FILE}..."
+            sed -i "s|^ARKADIA_ROOT=.*|ARKADIA_ROOT=${repo_root}|" "${ENV_FILE}"
+        else
+            info "${ENV_FILE} already exists with correct ARKADIA_ROOT."
+        fi
+        return
+    fi
+
+    info "Creating ${ENV_FILE}..."
+    cat > "${ENV_FILE}" << EOF
+# Arkadia environment file — loaded by all service units via EnvironmentFile=
+# Set these values before starting services.
+
+# Absolute path to the Arkadia repository on this machine.
+ARKADIA_ROOT=${repo_root}
+
+# API authentication key.  Change this to a strong random value before
+# starting the api service.  Generate one with:
+#   python3 -c "import secrets; print(secrets.token_hex(32))"
+MONITOR_API_KEY=${PLACEHOLDER_KEY}
+EOF
+    chmod 640 "${ENV_FILE}"
+    info "  Created ${ENV_FILE}."
+    warn "  MONITOR_API_KEY is set to a placeholder — update it before starting the API."
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 require_root
-install_mosquitto
-install_config
-enable_service
+SERVICE_USER="$(detect_service_user)"
+info "Repository root : ${REPO_ROOT}"
+info "Service user    : ${SERVICE_USER}"
 
-info "Done. Mosquitto is listening on 127.0.0.1:1883."
-info "Verify with:"
-info "  mosquitto_sub -h 127.0.0.1 -t 'test/#' &"
-info "  mosquitto_pub -h 127.0.0.1 -t 'test/hello' -m 'world'"
+install_packages
+install_mosquitto_config
+enable_i2c
+enable_i2s
+install_asound_conf
+create_virtualenvs "${SERVICE_USER}"
+scaffold_env_file "${REPO_ROOT}"
+
+info ""
+info "Setup complete."
+info ""
+info "Next steps:"
+info "  1. If I2S lines were added to ${BOOT_CONFIG}, reboot the Pi."
+info "  2. Update MONITOR_API_KEY in ${ENV_FILE}."
+info "  3. Run:  sudo bash scripts/deploy.sh"

--- a/services/api/api.service
+++ b/services/api/api.service
@@ -1,18 +1,37 @@
 [Unit]
 Description=Arkadia API Service
+Documentation=https://github.com/malonge/Arkadia
 After=mosquitto.service
 Requires=mosquitto.service
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple
+
+# Change 'pi' to your actual username.
 User=pi
-WorkingDirectory=/home/pi/Arkadia/services/api
-ExecStart=/home/pi/Arkadia/services/api/.venv/bin/python main.py
+
+# /etc/home-monitor.env must exist and define ARKADIA_ROOT — the absolute
+# path to this repository on the target machine.  Example:
+#   ARKADIA_ROOT=/home/pi/Projects/Arkadia
+# It must also define MONITOR_API_KEY for the API authentication key.
+EnvironmentFile=/etc/home-monitor.env
+
+# ExecStart uses /bin/bash so that the ARKADIA_ROOT variable from
+# EnvironmentFile can be expanded inside the quoted string.
+ExecStart=/bin/bash -c \
+  'exec "${ARKADIA_ROOT}/services/api/.venv/bin/python" \
+        "${ARKADIA_ROOT}/services/api/main.py"'
+
 Restart=on-failure
 RestartSec=5
-EnvironmentFile=/etc/home-monitor.env
+TimeoutStopSec=10
+
 StandardOutput=journal
 StandardError=journal
+SyslogIdentifier=api
+
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the automation layer specified in `docs/dev-plan.md` PR 7.  After merging, a fresh Raspberry Pi goes from zero to fully running with two commands:

```bash
sudo bash scripts/setup.sh
sudo bash scripts/deploy.sh
```

---

### `scripts/setup.sh` (complete rewrite of the PR 2 partial)

| Step | What it does |
|------|-------------|
| System packages | `apt-get install mosquitto mosquitto-clients python3-venv python3-dev i2c-tools libasound2-dev` |
| Mosquitto config | Copies `mosquitto/mosquitto.conf` → `/etc/mosquitto/conf.d/arkadia.conf`, enables and restarts the service |
| I2C | Calls `raspi-config nonint do_i2c 0`; skips gracefully if not on a Pi |
| I2S | Edits `/boot/firmware/config.txt` idempotently: adds `dtparam=i2s=on`, `dtoverlay=googlevoicehat-soundcard`, `dtparam=audio=on`; patches `vc4-kms-v3d` → `vc4-kms-v3d,noaudio` |
| ALSA softvol | Writes `/etc/asound.conf` (skipped if already present) |
| Virtualenvs | Creates `.venv` per service (bme280, scd40, audio, api); runs `pip install -e .` from repo root (installs `common`) + service `requirements.txt` |
| Env file | Scaffolds `/etc/home-monitor.env` with `ARKADIA_ROOT` and a placeholder `MONITOR_API_KEY`; if the file already exists, updates `ARKADIA_ROOT` only |

### `scripts/deploy.sh`

| Step | What it does |
|------|-------------|
| Preflight | Fails fast if `/etc/home-monitor.env` is missing or `ARKADIA_ROOT` is unset; warns if `MONITOR_API_KEY` is still the placeholder |
| Install units | Copies each `*.service` file to `/etc/systemd/system/`; replaces `User=pi` with the detected real user (`$SUDO_USER` or owner of repo root) |
| Enable | `systemctl daemon-reload` + `systemctl enable` for all four Arkadia units |
| Start order | `mosquitto` → `bme280 scd40 audio` (parallel) → `api` |
| Status report | Prints active/inactive state for all five services |

### `services/api/api.service` (fixed)

Rewritten to use the same `ARKADIA_ROOT`-via-EnvironmentFile + `/bin/bash` ExecStart pattern as the bme280, scd40, and audio units.  The previous version hardcoded `/home/pi/Arkadia/...` paths, which broke on any other username or path.

### Idempotency

Both scripts are safe to re-run.  Re-running `deploy.sh` after a code change restarts all Arkadia services with the new code.

---

**Testing**
- ✅ `shellcheck scripts/setup.sh scripts/deploy.sh` — no issues
- ✅ `ruff check .` — no issues  
- ✅ `pytest` — 243/243 passed
- ✅ Non-root guard: both scripts exit with a clear error when not run as root
- ✅ Deploy preflight: exits with `ERROR: /etc/home-monitor.env not found` when env file is absent
- ✅ Unit installation: all four `.service` files copied with `User=pi` → `User=ubuntu` substitution verified
- ✅ Placeholder warning fires when `MONITOR_API_KEY` is unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

