### PR TITLE
feat(lwt): add LWT and sensor status topics (PR 8)

### DIFF
--- a/services/api/config.toml
+++ b/services/api/config.toml
@@ -5,6 +5,7 @@ port = 8000
 [mqtt]
 client_id = "api-service"
 subscription = "home/sensors/#"
+status_subscription = "home/status/#"
 
 [sensors]
 known_ids = ["bme280", "scd40", "inmp441"]

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -24,7 +24,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from common.config import load_config  # noqa: E402
 from common.mqtt import MQTTClient, configure_logging  # noqa: E402
-from services.api.store import SensorStore  # noqa: E402
+from services.api.store import ConnectivityStore, SensorStore  # noqa: E402
 from services.api.ws import AudioStreamBroadcaster  # noqa: E402
 
 from services.api.routes import health as health_module  # noqa: E402
@@ -50,6 +50,7 @@ def _load_api_config() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 _STREAM_SUFFIX = "/stream"
+_STATUS_PREFIX = "home/status/"
 
 
 def _make_message_handler(
@@ -91,6 +92,46 @@ def _make_message_handler(
     return on_message
 
 
+def _make_status_handler(connectivity: ConnectivityStore) -> Any:
+    """Return a callback that updates connectivity status from ``home/status/#`` messages."""
+
+    def on_status(topic: str, payload: bytes) -> None:
+        # Derive sensor_id from the topic: "home/status/<sensor_id>"
+        sensor_id = topic[len(_STATUS_PREFIX):] if topic.startswith(_STATUS_PREFIX) else ""
+        if not sensor_id:
+            return
+
+        try:
+            data: dict[str, Any] = json.loads(payload.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            logger.warning(
+                "Non-JSON status payload on topic %s; ignoring",
+                topic,
+                extra={"event": "mqtt_bad_payload"},
+            )
+            return
+
+        raw_status = data.get("status", "")
+        if raw_status not in ("online", "offline"):
+            logger.warning(
+                "Unrecognised status %r for sensor %s; ignoring",
+                raw_status,
+                sensor_id,
+                extra={"event": "mqtt_bad_status"},
+            )
+            return
+
+        connectivity.update(sensor_id, raw_status)  # type: ignore[arg-type]
+        logger.info(
+            "Sensor %s is %s",
+            sensor_id,
+            raw_status,
+            extra={"event": f"sensor_{raw_status}"},
+        )
+
+    return on_status
+
+
 # ---------------------------------------------------------------------------
 # Lifespan
 # ---------------------------------------------------------------------------
@@ -121,6 +162,7 @@ async def _lifespan(app: FastAPI):
         )
 
     store = SensorStore()
+    connectivity = ConnectivityStore()
     broadcaster = AudioStreamBroadcaster()
     broadcaster.set_loop(asyncio.get_event_loop())
 
@@ -131,16 +173,18 @@ async def _lifespan(app: FastAPI):
         keepalive=broker_cfg.get("keepalive", 60),
     )
 
-    handler = _make_message_handler(store, broadcaster)
-    subscription = mqtt_cfg.get("subscription", "home/sensors/#")
-    mqtt_client.subscribe(subscription, handler, qos=1)
+    sensor_subscription = mqtt_cfg.get("subscription", "home/sensors/#")
+    status_subscription = mqtt_cfg.get("status_subscription", "home/status/#")
+    mqtt_client.subscribe(sensor_subscription, _make_message_handler(store, broadcaster), qos=1)
+    mqtt_client.subscribe(status_subscription, _make_status_handler(connectivity), qos=1)
 
     try:
         mqtt_client.connect()
         mqtt_client.loop_start()
         logger.info(
-            "MQTT client started; subscribed to %s",
-            subscription,
+            "MQTT client started; subscribed to %s and %s",
+            sensor_subscription,
+            status_subscription,
             extra={"event": "mqtt_subscribed"},
         )
     except Exception:
@@ -151,6 +195,7 @@ async def _lifespan(app: FastAPI):
 
     known_ids_raw = sensor_cfg.get("known_ids", ["bme280", "scd40", "inmp441"])
     app.state.store = store
+    app.state.connectivity = connectivity
     app.state.broadcaster = broadcaster
     app.state.mqtt_client = mqtt_client
     app.state.api_key = api_key

--- a/services/api/routes/sensors.py
+++ b/services/api/routes/sensors.py
@@ -90,6 +90,9 @@ async def get_sensor_status(sensor_id: str, request: Request) -> JSONResponse:
     seconds_since = (now - entry.received_at).total_seconds()
     stale = seconds_since > stale_threshold
 
+    connectivity_store = request.app.state.connectivity
+    connectivity = connectivity_store.get(sensor_id)
+
     return JSONResponse(
         content={
             "sensor_id": sensor_id,
@@ -97,5 +100,6 @@ async def get_sensor_status(sensor_id: str, request: Request) -> JSONResponse:
             "seconds_since_update": round(seconds_since, 1),
             "stale": stale,
             "stale_threshold_seconds": stale_threshold,
+            "connectivity": connectivity,
         }
     )

--- a/services/api/store.py
+++ b/services/api/store.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
+
+ConnectivityStatus = Literal["online", "offline", "unknown"]
 
 
 @dataclass
@@ -49,3 +51,35 @@ class SensorStore:
     def __len__(self) -> int:
         with self._lock:
             return len(self._data)
+
+
+class ConnectivityStore:
+    """Thread-safe map of sensor_id → connectivity status.
+
+    Updated by messages arriving on ``home/status/#``.
+
+    Status values:
+        ``"online"``   — the sensor service published a successful startup.
+        ``"offline"``  — the broker delivered the service's LWT (ungraceful exit)
+                         or the service explicitly published offline before stopping.
+        ``"unknown"``  — no status message has been received yet.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._data: dict[str, ConnectivityStatus] = {}
+
+    def update(self, sensor_id: str, status: ConnectivityStatus) -> None:
+        """Record *status* for *sensor_id*."""
+        with self._lock:
+            self._data[sensor_id] = status
+
+    def get(self, sensor_id: str) -> ConnectivityStatus:
+        """Return the current status for *sensor_id*, defaulting to ``"unknown"``."""
+        with self._lock:
+            return self._data.get(sensor_id, "unknown")
+
+    def all(self) -> dict[str, ConnectivityStatus]:
+        """Return a shallow copy of all known statuses."""
+        with self._lock:
+            return dict(self._data)

--- a/services/audio/main.py
+++ b/services/audio/main.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 from common.config import load_config
 from common.models import AudioPayload, AudioStreamPayload, Diagnostics, Meta, StreamMeta
-from common.mqtt import MQTTClient, configure_logging
+from common.mqtt import LWTConfig, MQTTClient, configure_logging
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -101,11 +101,18 @@ def main() -> None:
     broker = cfg["broker"]
     mqtt_cfg = cfg["mqtt"]
 
+    status_topic = "home/status/inmp441"
     client = MQTTClient(
         client_id=mqtt_cfg["client_id"],
         broker_host=broker["host"],
         broker_port=broker["port"],
         keepalive=broker["keepalive"],
+        lwt=LWTConfig(
+            topic=status_topic,
+            payload='{"status": "offline"}',
+            qos=1,
+            retain=True,
+        ),
     )
 
     try:
@@ -168,6 +175,12 @@ def main() -> None:
         )
         client.loop_stop()
         sys.exit(1)
+
+    try:
+        client.publish(status_topic, '{"status": "online"}', qos=1, retain=True)
+        logger.info("Published online status", extra={"event": "status_online"})
+    except RuntimeError as exc:
+        logger.warning("Could not publish online status: %s", exc)
 
     # ----------------------------------------------------------------
     # Publish settings

--- a/services/bme280/main.py
+++ b/services/bme280/main.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from common.config import load_config
 from common.i2c import I2CError
 from common.models import BME280Payload, BME280Readings, Diagnostics, Meta
-from common.mqtt import MQTTClient, configure_logging
+from common.mqtt import LWTConfig, MQTTClient, configure_logging
 
 # Ensure sensor.py is importable regardless of the working directory.
 # When running under systemd, WorkingDirectory is not set (to avoid
@@ -105,11 +105,18 @@ def main() -> None:
     broker = cfg["broker"]
     mqtt_cfg = cfg["mqtt"]
 
+    status_topic = "home/status/bme280"
     client = MQTTClient(
         client_id=mqtt_cfg["client_id"],
         broker_host=broker["host"],
         broker_port=broker["port"],
         keepalive=broker["keepalive"],
+        lwt=LWTConfig(
+            topic=status_topic,
+            payload='{"status": "offline"}',
+            qos=1,
+            retain=True,
+        ),
     )
 
     try:
@@ -149,6 +156,13 @@ def main() -> None:
         logger.critical("Sensor init failed: %s", exc, extra={"event": "sensor_error"})
         client.loop_stop()
         sys.exit(1)
+
+    # Announce successful startup so subscribers know this sensor is live.
+    try:
+        client.publish(status_topic, '{"status": "online"}', qos=1, retain=True)
+        logger.info("Published online status", extra={"event": "status_online"})
+    except RuntimeError as exc:
+        logger.warning("Could not publish online status: %s", exc)
 
     # ----------------------------------------------------------------
     # Poll loop

--- a/services/scd40/main.py
+++ b/services/scd40/main.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from common.config import load_config
 from common.i2c import I2CError
 from common.models import Diagnostics, Meta, SCD40Payload, SCD40Readings
-from common.mqtt import MQTTClient, configure_logging
+from common.mqtt import LWTConfig, MQTTClient, configure_logging
 
 # Ensure sensor.py is importable regardless of the working directory.
 sys.path.insert(0, str(Path(__file__).parent))
@@ -89,11 +89,18 @@ def main() -> None:
     broker = cfg["broker"]
     mqtt_cfg = cfg["mqtt"]
 
+    status_topic = "home/status/scd40"
     client = MQTTClient(
         client_id=mqtt_cfg["client_id"],
         broker_host=broker["host"],
         broker_port=broker["port"],
         keepalive=broker["keepalive"],
+        lwt=LWTConfig(
+            topic=status_topic,
+            payload='{"status": "offline"}',
+            qos=1,
+            retain=True,
+        ),
     )
 
     try:
@@ -133,6 +140,12 @@ def main() -> None:
         logger.critical("Sensor init failed: %s", exc, extra={"event": "sensor_error"})
         client.loop_stop()
         sys.exit(1)
+
+    try:
+        client.publish(status_topic, '{"status": "online"}', qos=1, retain=True)
+        logger.info("Published online status", extra={"event": "status_online"})
+    except RuntimeError as exc:
+        logger.warning("Could not publish online status: %s", exc)
 
     # ----------------------------------------------------------------
     # Poll loop

--- a/tests/test_api_connectivity.py
+++ b/tests/test_api_connectivity.py
@@ -1,0 +1,245 @@
+"""Tests for ConnectivityStore and the connectivity field in /sensors/{id}/status."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from services.api.routes import health as health_module
+from services.api.routes import sensors as sensors_module
+from services.api.routes import version as version_module
+from services.api.store import ConnectivityStore, SensorStore
+from services.api.ws import AudioStreamBroadcaster
+
+# ---------------------------------------------------------------------------
+# ConnectivityStore unit tests
+# ---------------------------------------------------------------------------
+
+_API_KEY = "test-key"
+
+
+class TestConnectivityStore:
+    def test_unknown_by_default(self):
+        cs = ConnectivityStore()
+        assert cs.get("bme280") == "unknown"
+
+    def test_update_online(self):
+        cs = ConnectivityStore()
+        cs.update("bme280", "online")
+        assert cs.get("bme280") == "online"
+
+    def test_update_offline(self):
+        cs = ConnectivityStore()
+        cs.update("bme280", "offline")
+        assert cs.get("bme280") == "offline"
+
+    def test_update_overwrites(self):
+        cs = ConnectivityStore()
+        cs.update("bme280", "online")
+        cs.update("bme280", "offline")
+        assert cs.get("bme280") == "offline"
+
+    def test_independent_sensors(self):
+        cs = ConnectivityStore()
+        cs.update("bme280", "online")
+        cs.update("scd40", "offline")
+        assert cs.get("bme280") == "online"
+        assert cs.get("scd40") == "offline"
+        assert cs.get("inmp441") == "unknown"
+
+    def test_all_returns_copy(self):
+        cs = ConnectivityStore()
+        cs.update("bme280", "online")
+        snapshot = cs.all()
+        cs.update("bme280", "offline")
+        assert snapshot["bme280"] == "online"
+
+    def test_thread_safe_concurrent_updates(self):
+        cs = ConnectivityStore()
+        errors: list[Exception] = []
+
+        def updater(sensor_id: str, status: str, n: int) -> None:
+            for _ in range(n):
+                try:
+                    cs.update(sensor_id, status)
+                    cs.get(sensor_id)
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [
+            threading.Thread(target=updater, args=(f"s{i}", "online", 300))
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+
+
+# ---------------------------------------------------------------------------
+# _make_status_handler unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakeStatusHandler:
+    def _handler(self, cs: ConnectivityStore):
+        from services.api.main import _make_status_handler
+        return _make_status_handler(cs)
+
+    def test_online_status_stored(self):
+        cs = ConnectivityStore()
+        h = self._handler(cs)
+        h("home/status/bme280", b'{"status": "online"}')
+        assert cs.get("bme280") == "online"
+
+    def test_offline_status_stored(self):
+        cs = ConnectivityStore()
+        h = self._handler(cs)
+        h("home/status/bme280", b'{"status": "offline"}')
+        assert cs.get("bme280") == "offline"
+
+    def test_unknown_sensor_id_extracted_from_topic(self):
+        cs = ConnectivityStore()
+        h = self._handler(cs)
+        h("home/status/inmp441", b'{"status": "online"}')
+        assert cs.get("inmp441") == "online"
+
+    def test_bad_json_is_ignored(self):
+        cs = ConnectivityStore()
+        h = self._handler(cs)
+        h("home/status/bme280", b"not-json")
+        assert cs.get("bme280") == "unknown"
+
+    def test_unrecognised_status_is_ignored(self):
+        cs = ConnectivityStore()
+        h = self._handler(cs)
+        h("home/status/bme280", b'{"status": "degraded"}')
+        assert cs.get("bme280") == "unknown"
+
+    def test_wrong_topic_prefix_is_ignored(self):
+        cs = ConnectivityStore()
+        h = self._handler(cs)
+        h("home/sensors/climate/bme280", b'{"status": "online"}')
+        assert cs.get("bme280") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# /sensors/{id}/status connectivity field — route tests
+# ---------------------------------------------------------------------------
+
+
+def _make_app(
+    store: SensorStore | None = None,
+    connectivity: ConnectivityStore | None = None,
+    known_ids: set[str] | None = None,
+) -> FastAPI:
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from fastapi.responses import JSONResponse
+    from fastapi import Request
+
+    if store is None:
+        store = SensorStore()
+    if connectivity is None:
+        connectivity = ConnectivityStore()
+    if known_ids is None:
+        known_ids = {"bme280", "scd40", "inmp441"}
+
+    mock_mqtt = MagicMock()
+    mock_mqtt.is_connected = True
+
+    app = FastAPI()
+
+    class APIKeyMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next):
+            exempt = {"/health", "/docs", "/openapi.json", "/redoc"}
+            if request.url.path in exempt:
+                return await call_next(request)
+            provided = request.headers.get("X-API-Key", "")
+            if provided != _API_KEY:
+                return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+            return await call_next(request)
+
+    app.add_middleware(APIKeyMiddleware)
+    app.include_router(health_module.router)
+    app.include_router(version_module.router)
+    app.include_router(sensors_module.router)
+
+    app.state.store = store
+    app.state.connectivity = connectivity
+    app.state.broadcaster = AudioStreamBroadcaster()
+    app.state.mqtt_client = mock_mqtt
+    app.state.api_key = _API_KEY
+    app.state.known_sensor_ids = known_ids
+    app.state.stale_threshold_seconds = 120
+
+    return app
+
+
+class TestSensorStatusConnectivity:
+    _H = {"X-API-Key": _API_KEY}
+
+    def test_connectivity_unknown_by_default(self):
+        store = SensorStore()
+        store.upsert("bme280", {"sensor_id": "bme280"})
+        app = _make_app(store=store)
+        with TestClient(app) as c:
+            r = c.get("/sensors/bme280/status", headers=self._H)
+        assert r.status_code == 200
+        assert r.json()["connectivity"] == "unknown"
+
+    def test_connectivity_online(self):
+        store = SensorStore()
+        store.upsert("bme280", {"sensor_id": "bme280"})
+        cs = ConnectivityStore()
+        cs.update("bme280", "online")
+        app = _make_app(store=store, connectivity=cs)
+        with TestClient(app) as c:
+            r = c.get("/sensors/bme280/status", headers=self._H)
+        assert r.json()["connectivity"] == "online"
+
+    def test_connectivity_offline(self):
+        store = SensorStore()
+        store.upsert("bme280", {"sensor_id": "bme280"})
+        cs = ConnectivityStore()
+        cs.update("bme280", "offline")
+        app = _make_app(store=store, connectivity=cs)
+        with TestClient(app) as c:
+            r = c.get("/sensors/bme280/status", headers=self._H)
+        assert r.json()["connectivity"] == "offline"
+
+    def test_status_response_includes_all_fields(self):
+        store = SensorStore()
+        store.upsert("bme280", {"sensor_id": "bme280"})
+        cs = ConnectivityStore()
+        cs.update("bme280", "online")
+        app = _make_app(store=store, connectivity=cs)
+        with TestClient(app) as c:
+            r = c.get("/sensors/bme280/status", headers=self._H)
+        body = r.json()
+        assert set(body.keys()) >= {
+            "sensor_id",
+            "last_seen",
+            "seconds_since_update",
+            "stale",
+            "stale_threshold_seconds",
+            "connectivity",
+        }
+
+    def test_different_sensors_have_independent_connectivity(self):
+        store = SensorStore()
+        store.upsert("bme280", {"sensor_id": "bme280"})
+        store.upsert("scd40", {"sensor_id": "scd40"})
+        cs = ConnectivityStore()
+        cs.update("bme280", "online")
+        cs.update("scd40", "offline")
+        app = _make_app(store=store, connectivity=cs)
+        with TestClient(app) as c:
+            r1 = c.get("/sensors/bme280/status", headers=self._H)
+            r2 = c.get("/sensors/scd40/status", headers=self._H)
+        assert r1.json()["connectivity"] == "online"
+        assert r2.json()["connectivity"] == "offline"

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from services.api.routes import health as health_module
 from services.api.routes import sensors as sensors_module
 from services.api.routes import version as version_module
-from services.api.store import SensorStore
+from services.api.store import ConnectivityStore, SensorStore
 from services.api.ws import AudioStreamBroadcaster
 
 # ---------------------------------------------------------------------------
@@ -38,6 +38,7 @@ def _make_app(
         store = SensorStore()
     if known_ids is None:
         known_ids = _KNOWN_IDS
+    connectivity = ConnectivityStore()
 
     mock_mqtt = MagicMock()
     mock_mqtt.is_connected = True
@@ -66,6 +67,7 @@ def _make_app(
     app.include_router(sensors_module.router)
 
     app.state.store = store
+    app.state.connectivity = connectivity
     app.state.broadcaster = broadcaster
     app.state.mqtt_client = mock_mqtt
     app.state.api_key = api_key


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements PR 8 — Last Will and Testament messages and sensor connectivity tracking.

### Sensor services (bme280, scd40, audio)

Each service now:
1. Registers a **LWT** with the broker at connect time: topic `home/status/{sensor_id}`, payload `{"status": "offline"}`, QoS 1, `retain=true`. If the service dies ungracefully the broker publishes this automatically within one keepalive interval.
2. Publishes `{"status": "online"}` to `home/status/{sensor_id}` (QoS 1, `retain=true`) immediately after hardware initialisation succeeds.

Sensor IDs: `bme280`, `scd40`, `inmp441`.

### API service

| File | Change |
|------|--------|
| `services/api/store.py` | New `ConnectivityStore` — thread-safe `dict[sensor_id, "online"\|"offline"\|"unknown"]` |
| `services/api/main.py` | New `_make_status_handler`; second MQTT subscription on `home/status/#`; `app.state.connectivity` wired up |
| `services/api/config.toml` | Added `status_subscription = "home/status/#"` |
| `services/api/routes/sensors.py` | `GET /sensors/{id}/status` now includes a `connectivity` field |

### `GET /sensors/{sensor_id}/status` response shape

```json
{
  "sensor_id": "bme280",
  "last_seen": "2026-05-25T15:46:43Z",
  "seconds_since_update": 3.3,
  "stale": false,
  "stale_threshold_seconds": 120,
  "connectivity": "online"
}
```

`connectivity` is `"online"` / `"offline"` / `"unknown"` (unknown until the first status message arrives after broker startup).

### Tests

18 new tests in `tests/test_api_connectivity.py`:
- `ConnectivityStore` — update/get/all, overwrite, multi-sensor independence, thread-safety under concurrent writes
- `_make_status_handler` — online/offline dispatch, sensor_id extraction from topic, bad JSON, unrecognised status value, wrong topic prefix
- Route — `connectivity` field present and correct for all three status values; independent per sensor

`tests/test_api_routes.py` updated to inject `ConnectivityStore` into the test app factory.

**Testing**
- ✅ `ruff check .` — clean
- ✅ `pytest` — 261/261 passed (18 new tests)
- ✅ Live smoke test: `mosquitto_pub … home/status/bme280 {"status":"online"}` → status endpoint returns `"connectivity": "online"`; publishing offline → `"connectivity": "offline"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

