### PR TITLE
feat(web): scaffold Svelte+Vite web app and retro design system (PR 9)

### DIFF
--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -237,6 +237,111 @@ The `googlevoicehat-soundcard` ALSA driver used on Pi 5 / Bookworm requires **48
 
 ---
 
+## PR 9 — Web App Scaffold & Retro Design System
+
+**Goal:** Initialize the `web/` Svelte + Vite project and establish every visual building block. No live data yet — all three sensor panels show shells with placeholder content. Subsequent PRs wire in the real data.
+
+### Stack
+
+- **Framework:** Svelte 5 + Vite
+- **Fonts:** Press Start 2P (headings/labels), VT323 (numeric readouts) — Google Fonts, loaded by the browser
+- **Color palette:** Green terminal (`#0d0208` background, `#00ff41` primary, `#39ff14` accent)
+- **Canvas:** native `<canvas>` — no charting library
+- **Deployment target:** static files eventually served by FastAPI `StaticFiles` (PR 12)
+
+### Scope
+
+- `web/package.json`, `web/vite.config.js`, `web/index.html`
+- `web/src/styles/global.css` — CSS custom properties (palette, typography, spacing), pixel border helper, scanline overlay, screen flicker, blinking cursor, 7-segment font class
+- `web/src/main.js` — Svelte mount point
+- `web/src/App.svelte` — three-panel grid, boot-sequence typewriter, settings gate
+- `web/src/api.js` — API client: reads key from `localStorage`, exports `fetchSensors()`, `fetchSensorStatus()`, `createAudioStream()`; no real calls yet (stubs)
+- `web/src/components/Header.svelte` — service name, version badge, blinking `█` cursor
+- `web/src/components/SensorCard.svelte` — pixel-border panel; props: `title`, `sensorId`, `connectivity` (`"online"`/`"offline"`/`"unknown"`), `lastSeen`; default slot for readings content
+- `web/src/components/StatusBar.svelte` — last poll time, broker connectivity dot
+- `web/src/components/SettingsModal.svelte` — API key input; saves to `localStorage`; blocks app until key saved
+
+### Acceptance Criteria
+
+- `npm run dev` serves the app at `http://localhost:5173`.
+- `npm run build` produces `web/dist/` with no errors.
+- Settings modal appears on first load when `localStorage` has no key.
+- Three SensorCard panels render with pixel borders and correct retro styling.
+- Scanline overlay and screen flicker are visible.
+- Header shows blinking cursor.
+- Connectivity dots render in all three states (green/red/grey) when manually set in the component.
+
+---
+
+## PR 10 — Climate & Air Panels
+
+**Goal:** Wire the BME280 and SCD40 panels to live data from the API.
+
+### Scope
+
+- `web/src/components/TemperatureGauge.svelte` — vertical column of 16 discrete pixel blocks; color shifts blue → green → yellow → red
+- `web/src/components/BarMeter.svelte` — horizontal row of discrete pixel blocks; accepts `value`, `min`, `max`, `thresholds` (for color changes)
+- `web/src/components/SevenSegDisplay.svelte` — numeric readout styled as a 7-segment LED display using CSS `font-variant-numeric` + VT323
+- Climate panel: temperature (gauge + number), humidity (bar + %), pressure (7-seg hPa)
+- Air quality panel: CO₂ ppm (7-seg + bar colored green/amber/red by threshold), temperature/humidity if available
+- Polling loop in `App.svelte`: `fetchSensors()` every 30 s; staleness from `fetchSensorStatus()`; retry on error with exponential backoff
+- Display stale indicator (dimmed readings + `⚠ STALE` badge) when sensor is stale
+
+### Acceptance Criteria
+
+- Panels show live readings from the API, updating every 30 seconds.
+- CO₂ bar color changes at 800 ppm (amber) and 1 200 ppm (red).
+- Stale indicator appears when `stale: true` is returned by the status endpoint.
+- Readings display correctly when the API is unreachable (last known value held, error badge shown).
+
+---
+
+## PR 11 — Audio Panel
+
+**Goal:** Real-time audio visualization using the WebSocket stream.
+
+### Scope
+
+- `web/src/components/EQVisualizer.svelte` — `<canvas>`; 8 pixel columns (one per ISO band) with discrete step heights; peak hold dots; smooth decay animation; idle animation when disconnected
+- `web/src/components/WaveformScope.svelte` — `<canvas>`; pixelated oscilloscope line (amplitude snapped to grid); phosphor glow via `shadowBlur`; flat idle line when disconnected
+- WebSocket client in `api.js`: `createAudioStream(onFrame, onStatus)` — connects to `/ws/audio/stream?api_key=<key>`, parses `AudioStreamPayload` JSON, calls `onFrame`; reconnects with exponential backoff on disconnect
+- Audio panel: EQ bars (top), waveform scope (bottom), RMS dBFS readout (7-seg), connectivity status
+- Summary RMS from `GET /sensors/inmp441` (polled with other sensors) shown as a secondary number
+
+### Acceptance Criteria
+
+- EQ bars update at approximately 20 Hz while the audio service is running.
+- Waveform updates at approximately 20 Hz.
+- Disconnecting from WebSocket triggers the idle animation within 500 ms.
+- Reconnecting resumes live data without page reload.
+- Second browser tab receives the same stream simultaneously.
+
+---
+
+## PR 12 — FastAPI Integration & Deployment
+
+**Goal:** Serve the web app from the API service and automate the build in `deploy.sh`.
+
+### Scope
+
+- Prefix all existing API routes with `/api` (add `prefix="/api"` to each router's `include_router` call in `main.py`)
+- Update `api.js` base URL to `/api`
+- Mount `web/dist/` as `StaticFiles` at `/` in `main.py`
+- Update `services/api/requirements.txt` to add `aiofiles` (required for `StaticFiles`)
+- `scripts/deploy.sh`: add build step — `cd "${REPO_ROOT}/web" && npm ci && npm run build`
+- `scripts/setup.sh`: add Node.js install step — `apt-get install -y nodejs npm`
+- Update `README.md` with access URL (`http://<pi-hostname>:8000/`)
+- Smoke test: `curl http://localhost:8000/` returns the HTML shell; `curl http://localhost:8000/api/health` returns `{"status":"ok",...}`
+
+### Acceptance Criteria
+
+- Opening `http://<pi>:8000/` in a browser loads the dashboard.
+- All API endpoints remain functional at `/api/*`.
+- Re-running `deploy.sh` rebuilds the web app and restarts the API service.
+- `setup.sh` installs Node.js on a fresh Pi.
+
+---
+
 ## Reference: Design Document Decisions Carried Into This Breakdown
 
 | Decision | Reflected In |

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,7 +59,33 @@ install_packages() {
         python3-venv \
         python3-dev \
         i2c-tools \
-        libasound2-dev
+        libasound2-dev \
+        curl
+}
+
+# ---------------------------------------------------------------------------
+# Node.js 22 (via NodeSource — Debian/Bookworm ships Node 18 which is too old)
+# ---------------------------------------------------------------------------
+
+install_nodejs() {
+    # Skip if Node 20+ is already present.
+    if command -v node &>/dev/null; then
+        local ver
+        ver="$(node --version | sed 's/v//' | cut -d. -f1)"
+        if [[ "${ver}" -ge 20 ]]; then
+            info "Node.js $(node --version) already installed — skipping."
+            return
+        fi
+        info "Found Node.js v${ver} (too old); upgrading to Node.js 22…"
+    fi
+
+    info "Adding NodeSource Node.js 22 repository…"
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - 2>/dev/null
+
+    info "Installing Node.js 22…"
+    apt-get install -y -qq nodejs
+
+    info "Node.js $(node --version) installed."
 }
 
 # ---------------------------------------------------------------------------
@@ -264,6 +290,7 @@ info "Repository root : ${REPO_ROOT}"
 info "Service user    : ${SERVICE_USER}"
 
 install_packages
+install_nodejs
 install_mosquitto_config
 enable_i2c
 enable_i2s

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.vite/

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ARKADIA</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1146 @@
+{
+  "name": "arkadia-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "arkadia-web",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "svelte": "^5.55.9",
+        "vite": "^8.0.14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
+      "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.0",
+        "vitefu": "^1.1.2"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "svelte": "^5.46.4",
+        "vite": "^8.0.0-beta.7 || ^8.0.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.55.9",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.9.tgz",
+      "integrity": "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.9",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "arkadia-web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "svelte": "^5.55.9",
+    "vite": "^8.0.14"
+  }
+}

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#0d0208"/>
+  <rect x="3" y="3" width="10" height="10" fill="none" stroke="#00ff41" stroke-width="2"/>
+  <rect x="6" y="6" width="4" height="4" fill="#00ff41"/>
+</svg>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,0 +1,295 @@
+<script>
+  import { onMount } from 'svelte';
+  import { getApiKey } from './api.js';
+  import Header from './components/Header.svelte';
+  import SensorCard from './components/SensorCard.svelte';
+  import StatusBar from './components/StatusBar.svelte';
+  import SettingsModal from './components/SettingsModal.svelte';
+
+  // ---------------------------------------------------------------------------
+  // Settings gate
+  // ---------------------------------------------------------------------------
+  let apiKey = $state(getApiKey());
+  let showSettings = $state(!getApiKey());
+
+  function handleSave(key) {
+    apiKey = key;
+    showSettings = false;
+    // Re-trigger boot when key is set for the first time
+    startBoot();
+  }
+
+  function openSettings() {
+    showSettings = true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Boot sequence
+  // ---------------------------------------------------------------------------
+  const BOOT_LINES = [
+    'ARKADIA SYSTEM v1.1.0',
+    'INITIALISING SENSORS…',
+    'CONNECTING TO BROKER…',
+    'LOADING DASHBOARD…',
+    '',
+  ];
+
+  let booting = $state(true);
+  let bootLines = $state([]);
+  let bootDone = $state(false);
+
+  function startBoot() {
+    booting = true;
+    bootLines = [];
+    bootDone = false;
+
+    let lineIdx = 0;
+    let charIdx = 0;
+    let current = '';
+
+    function tick() {
+      if (lineIdx >= BOOT_LINES.length) {
+        bootDone = true;
+        setTimeout(() => { booting = false; }, 300);
+        return;
+      }
+      const line = BOOT_LINES[lineIdx];
+      if (charIdx < line.length) {
+        current += line[charIdx];
+        bootLines = [...bootLines.slice(0, lineIdx), current];
+        charIdx++;
+        setTimeout(tick, 28);
+      } else {
+        bootLines = [...bootLines.slice(0, lineIdx), current];
+        lineIdx++;
+        charIdx = 0;
+        current = '';
+        setTimeout(tick, lineIdx === BOOT_LINES.length ? 400 : 80);
+      }
+    }
+
+    tick();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Placeholder sensor state (data wired in PR 10/11)
+  // ---------------------------------------------------------------------------
+  // These will be replaced by real API polling in subsequent PRs.
+  const sensors = {
+    bme280:  { title: 'CLIMATE',     connectivity: 'unknown', lastSeen: null, stale: false },
+    scd40:   { title: 'AIR QUALITY', connectivity: 'unknown', lastSeen: null, stale: false },
+    inmp441: { title: 'AUDIO',       connectivity: 'unknown', lastSeen: null, stale: false },
+  };
+
+  let brokerConnected = $state(false);
+  let lastPoll = $state(null);
+  let pollError = $state(false);
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+  onMount(() => {
+    if (apiKey) startBoot();
+  });
+</script>
+
+<!-- Settings modal blocks everything until key is entered -->
+{#if showSettings}
+  <SettingsModal onSave={handleSave} />
+{/if}
+
+<!-- Boot sequence overlay -->
+{#if !showSettings && booting}
+  <div class="boot-screen" aria-live="polite">
+    <div class="boot-lines">
+      {#each bootLines as line, i}
+        <div class="boot-line">
+          <span class="dim">&gt;</span>
+          {line}{#if i === bootLines.length - 1 && !bootDone}<span class="cursor">█</span>{/if}
+        </div>
+      {/each}
+    </div>
+  </div>
+{/if}
+
+<!-- Main dashboard (rendered behind boot overlay for instant display after fade) -->
+{#if !showSettings}
+  <div class="layout" class:hidden={booting}>
+    <Header
+      brokerConnected={brokerConnected}
+      onSettingsClick={openSettings}
+    />
+
+    <main class="dashboard">
+      <!-- Climate panel -->
+      <SensorCard
+        title={sensors.bme280.title}
+        sensorId="bme280"
+        connectivity={sensors.bme280.connectivity}
+        lastSeen={sensors.bme280.lastSeen}
+        stale={sensors.bme280.stale}
+      >
+        <div class="placeholder-body">
+          <p class="label">TEMPERATURE</p>
+          <p class="value dimmer">—.— °C</p>
+          <p class="label">HUMIDITY</p>
+          <p class="value dimmer">—— %</p>
+          <p class="label">PRESSURE</p>
+          <p class="value dimmer">———— hPa</p>
+          <p class="coming-soon muted">LIVE DATA IN PR 10</p>
+        </div>
+      </SensorCard>
+
+      <!-- Air quality panel -->
+      <SensorCard
+        title={sensors.scd40.title}
+        sensorId="scd40"
+        connectivity={sensors.scd40.connectivity}
+        lastSeen={sensors.scd40.lastSeen}
+        stale={sensors.scd40.stale}
+      >
+        <div class="placeholder-body">
+          <p class="label">CO₂</p>
+          <p class="value dimmer">———— ppm</p>
+          <p class="label">TEMPERATURE</p>
+          <p class="value dimmer">—.— °C</p>
+          <p class="label">HUMIDITY</p>
+          <p class="value dimmer">—— %</p>
+          <p class="coming-soon muted">LIVE DATA IN PR 10</p>
+        </div>
+      </SensorCard>
+
+      <!-- Audio panel -->
+      <SensorCard
+        title={sensors.inmp441.title}
+        sensorId="inmp441"
+        connectivity={sensors.inmp441.connectivity}
+        lastSeen={sensors.inmp441.lastSeen}
+        stale={sensors.inmp441.stale}
+      >
+        <div class="placeholder-body">
+          <!-- EQ bar placeholder -->
+          <div class="eq-placeholder" aria-hidden="true">
+            {#each [6, 10, 8, 14, 12, 9, 5, 7] as h}
+              <div class="eq-col" style="height: {h * 6}px"></div>
+            {/each}
+          </div>
+          <p class="label">RMS LEVEL</p>
+          <p class="value dimmer">—— dBFS</p>
+          <p class="coming-soon muted">LIVE AUDIO IN PR 11</p>
+        </div>
+      </SensorCard>
+    </main>
+
+    <StatusBar
+      lastPoll={lastPoll}
+      pollError={pollError}
+      brokerConnected={brokerConnected}
+    />
+  </div>
+{/if}
+
+<style>
+  /* Boot screen */
+  .boot-screen {
+    position: fixed;
+    inset: 0;
+    background: var(--bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 7000;
+  }
+
+  .boot-lines {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u3);
+    padding: var(--u8);
+  }
+
+  .boot-line {
+    font-family: var(--font-pixel);
+    font-size: 10px;
+    color: var(--primary);
+    letter-spacing: 0.05em;
+    white-space: pre;
+  }
+
+  .dim {
+    color: var(--dim);
+    margin-right: var(--u2);
+  }
+
+  /* Main layout */
+  .layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    transition: opacity 0.3s;
+  }
+
+  .layout.hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* Dashboard grid */
+  .dashboard {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--u4);
+    padding: var(--u5) var(--u6);
+    align-items: start;
+  }
+
+  @media (max-width: 900px) {
+    .dashboard {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  @media (max-width: 580px) {
+    .dashboard {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Placeholder content inside cards */
+  .placeholder-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u3);
+  }
+
+  .value {
+    font-family: var(--font-vt);
+    font-size: 40px;
+    line-height: 1;
+  }
+
+  .coming-soon {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+    margin-top: var(--u3);
+    padding-top: var(--u3);
+    border-top: 1px solid var(--dimmer);
+  }
+
+  /* Static EQ bar placeholder */
+  .eq-placeholder {
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+    height: 90px;
+    padding-bottom: var(--u2);
+    border-bottom: 1px solid var(--dimmer);
+  }
+
+  .eq-col {
+    flex: 1;
+    background: var(--dimmer);
+    min-width: 8px;
+  }
+</style>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,10 +1,11 @@
 <script>
   import { onMount } from 'svelte';
-  import { getApiKey } from './api.js';
+  import { getApiKey, dbfsToDB } from './api.js';
   import Header from './components/Header.svelte';
   import SensorCard from './components/SensorCard.svelte';
   import StatusBar from './components/StatusBar.svelte';
   import SettingsModal from './components/SettingsModal.svelte';
+  import ReadingRow from './components/ReadingRow.svelte';
 
   // ---------------------------------------------------------------------------
   // Settings gate
@@ -129,15 +130,10 @@
         lastSeen={sensors.bme280.lastSeen}
         stale={sensors.bme280.stale}
       >
-        <div class="placeholder-body">
-          <p class="label">TEMPERATURE</p>
-          <p class="value dimmer">—.— °C</p>
-          <p class="label">HUMIDITY</p>
-          <p class="value dimmer">—— %</p>
-          <p class="label">PRESSURE</p>
-          <p class="value dimmer">———— hPa</p>
-          <p class="coming-soon muted">LIVE DATA IN PR 10</p>
-        </div>
+        <ReadingRow label="TEMPERATURE" value="—.—" unit="°C"  status="unknown" />
+        <ReadingRow label="HUMIDITY"    value="——"  unit="%"    status="unknown" />
+        <ReadingRow label="PRESSURE"    value="————" unit=" hPa" status="unknown" />
+        <p class="coming-soon muted">LIVE DATA IN PR 10</p>
       </SensorCard>
 
       <!-- Air quality panel -->
@@ -148,15 +144,10 @@
         lastSeen={sensors.scd40.lastSeen}
         stale={sensors.scd40.stale}
       >
-        <div class="placeholder-body">
-          <p class="label">CO₂</p>
-          <p class="value dimmer">———— ppm</p>
-          <p class="label">TEMPERATURE</p>
-          <p class="value dimmer">—.— °C</p>
-          <p class="label">HUMIDITY</p>
-          <p class="value dimmer">—— %</p>
-          <p class="coming-soon muted">LIVE DATA IN PR 10</p>
-        </div>
+        <ReadingRow label="CO₂"         value="————" unit=" ppm" status="unknown" />
+        <ReadingRow label="TEMPERATURE" value="—.—"  unit="°C"  status="unknown" />
+        <ReadingRow label="HUMIDITY"    value="——"   unit="%"    status="unknown" />
+        <p class="coming-soon muted">LIVE DATA IN PR 10</p>
       </SensorCard>
 
       <!-- Audio panel -->
@@ -167,17 +158,49 @@
         lastSeen={sensors.inmp441.lastSeen}
         stale={sensors.inmp441.stale}
       >
-        <div class="placeholder-body">
-          <!-- EQ bar placeholder -->
-          <div class="eq-placeholder" aria-hidden="true">
-            {#each [6, 10, 8, 14, 12, 9, 5, 7] as h}
-              <div class="eq-col" style="height: {h * 6}px"></div>
-            {/each}
-          </div>
-          <p class="label">RMS LEVEL</p>
-          <p class="value dimmer">—— dBFS</p>
-          <p class="coming-soon muted">LIVE AUDIO IN PR 11</p>
+        <!-- EQ bar placeholder with colored tops -->
+        <div class="eq-placeholder" aria-label="Equalizer placeholder">
+          {#each [
+            { h: 6,  top: 'ok'     },
+            { h: 10, top: 'good'   },
+            { h: 8,  top: 'ok'     },
+            { h: 14, top: 'warn'   },
+            { h: 12, top: 'warn'   },
+            { h: 9,  top: 'ok'     },
+            { h: 5,  top: 'good'   },
+            { h: 7,  top: 'ok'     },
+          ] as bar}
+            <div class="eq-col" style="height: {bar.h * 6}px">
+              <div class="eq-top eq-top--{bar.top}"></div>
+            </div>
+          {/each}
         </div>
+
+        <!-- Waveform oscilloscope placeholder -->
+        <div class="waveform-placeholder" aria-label="Waveform oscilloscope placeholder">
+          <span class="label">WAVEFORM</span>
+          <div class="waveform-screen">
+            <svg width="100%" height="48" preserveAspectRatio="none" aria-hidden="true">
+              <!-- idle flat line with slight noise -->
+              <polyline
+                points="0,24 20,24 40,23 60,25 80,24 100,24 120,23 140,25 160,24 180,24 200,23 220,25 240,24 260,24 280,23 300,25 320,24"
+                fill="none"
+                stroke="var(--dimmer)"
+                stroke-width="1.5"
+              />
+            </svg>
+          </div>
+        </div>
+
+        <!-- Level readings: dBFS + estimated dB SPL -->
+        <ReadingRow
+          label="LEVEL"
+          value="——"
+          unit=" dBFS"
+          status="unknown"
+          sub="~—— dB SPL"
+        />
+        <p class="coming-soon muted">LIVE AUDIO IN PR 11</p>
       </SensorCard>
     </main>
 
@@ -256,40 +279,58 @@
     }
   }
 
-  /* Placeholder content inside cards */
-  .placeholder-body {
-    display: flex;
-    flex-direction: column;
-    gap: var(--u3);
-  }
-
-  .value {
-    font-family: var(--font-vt);
-    font-size: 40px;
-    line-height: 1;
-  }
-
   .coming-soon {
     font-family: var(--font-pixel);
     font-size: 7px;
-    margin-top: var(--u3);
+    margin-top: var(--u2);
     padding-top: var(--u3);
     border-top: 1px solid var(--dimmer);
   }
 
-  /* Static EQ bar placeholder */
+  /* EQ bar placeholder */
   .eq-placeholder {
     display: flex;
     align-items: flex-end;
     gap: 4px;
     height: 90px;
-    padding-bottom: var(--u2);
+    padding-bottom: 0;
     border-bottom: 1px solid var(--dimmer);
+    margin-bottom: var(--u2);
   }
 
   .eq-col {
     flex: 1;
-    background: var(--dimmer);
     min-width: 8px;
+    background: var(--dim);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+
+  /* Top 3-pixel cap on each EQ bar — color indicates amplitude */
+  .eq-top {
+    height: 4px;
+    width: 100%;
+    flex-shrink: 0;
+  }
+
+  .eq-top--good   { background: var(--status-good);   box-shadow: 0 0 4px var(--status-good);   }
+  .eq-top--ok     { background: var(--status-ok);     box-shadow: 0 0 4px var(--status-ok);     }
+  .eq-top--warn   { background: var(--status-warn);   box-shadow: 0 0 4px var(--status-warn);   }
+  .eq-top--danger { background: var(--status-danger); box-shadow: 0 0 4px var(--status-danger); }
+
+  /* Waveform oscilloscope placeholder */
+  .waveform-placeholder {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u2);
+  }
+
+  .waveform-screen {
+    background: var(--bg);
+    border: 1px solid var(--dimmer);
+    padding: var(--u2);
+    box-shadow: inset 0 0 8px rgba(0, 255, 65, 0.04);
   }
 </style>

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -6,6 +6,97 @@
  * never appears in source code.
  */
 
+// ---------------------------------------------------------------------------
+// Location (hardcoded until GPS is integrated)
+// ---------------------------------------------------------------------------
+
+export const LOCATION = {
+  lat:  34.0792184,
+  lon: -118.3549672,
+  /** Compact display string, e.g. "34.0792°N, 118.3550°W" */
+  label: '34.0792°N, 118.3550°W',
+};
+
+// ---------------------------------------------------------------------------
+// Audio calibration
+// ---------------------------------------------------------------------------
+
+/**
+ * Approximate offset from dBFS to dB SPL for the INMP441 microphone.
+ * INMP441 sensitivity: −26 dBFS at 94 dB SPL (1 kHz, 1 Pa)
+ * → offset = 94 − (−26) = 120
+ *
+ * Apply as:  dB_SPL ≈ dBFS + INMP441_OFFSET
+ * Label results with "~" to indicate they are uncalibrated.
+ */
+export const INMP441_OFFSET = 120;
+
+/** Convert a dBFS value to approximate dB SPL. */
+export function dbfsToDB(dbfs) {
+  return dbfs + INMP441_OFFSET;
+}
+
+// ---------------------------------------------------------------------------
+// Threshold helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a status string for a numeric value given an ordered threshold table.
+ *
+ * @param {number} value
+ * @param {Array<[number, number, string]>} ranges  Each entry: [lo, hi, status]
+ *   where lo is inclusive and hi is exclusive.  Ranges should be exhaustive.
+ * @returns {'good'|'ok'|'warn'|'danger'|'unknown'}
+ */
+export function statusFor(value, ranges) {
+  if (value == null || isNaN(value)) return 'unknown';
+  for (const [lo, hi, status] of ranges) {
+    if (value >= lo && value < hi) return status;
+  }
+  return 'unknown';
+}
+
+export const THRESHOLDS = {
+  /** Temperature in °C */
+  temperature_c: [
+    [-Infinity, 10,  'danger'],
+    [10,        16,  'warn'  ],
+    [16,        26,  'good'  ],
+    [26,        30,  'ok'    ],
+    [30,  Infinity,  'danger'],
+  ],
+  /** Relative humidity in % */
+  humidity_pct: [
+    [-Infinity, 25,  'warn'  ],
+    [25,        30,  'ok'    ],
+    [30,        60,  'good'  ],
+    [60,        70,  'ok'    ],
+    [70,  Infinity,  'warn'  ],
+  ],
+  /** Atmospheric pressure in hPa */
+  pressure_hpa: [
+    [-Infinity, 980,  'warn'  ],
+    [980,       990,  'ok'    ],
+    [990,       1025, 'good'  ],
+    [1025,      1035, 'ok'    ],
+    [1035, Infinity,  'warn'  ],
+  ],
+  /** CO₂ in ppm */
+  co2_ppm: [
+    [-Infinity, 800,  'good'  ],
+    [800,       1000, 'ok'    ],
+    [1000,      1200, 'warn'  ],
+    [1200, Infinity,  'danger'],
+  ],
+  /** Audio RMS dBFS */
+  db_level: [
+    [-Infinity, -60,  'ok'    ],
+    [-60,       -30,  'good'  ],
+    [-30,       -10,  'warn'  ],
+    [-10,  Infinity,  'danger'],
+  ],
+};
+
 const BASE = '/api';
 const KEY_STORAGE = 'arkadia_api_key';
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -1,0 +1,136 @@
+/**
+ * Arkadia API client.
+ *
+ * All calls go to /api/* (proxied to FastAPI in dev; served from the same
+ * origin in production).  The API key is read from localStorage so it
+ * never appears in source code.
+ */
+
+const BASE = '/api';
+const KEY_STORAGE = 'arkadia_api_key';
+
+// ---------------------------------------------------------------------------
+// Key management
+// ---------------------------------------------------------------------------
+
+export function getApiKey() {
+  return localStorage.getItem(KEY_STORAGE) ?? '';
+}
+
+export function setApiKey(key) {
+  localStorage.setItem(KEY_STORAGE, key);
+}
+
+export function clearApiKey() {
+  localStorage.removeItem(KEY_STORAGE);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+function headers() {
+  return {
+    'X-API-Key': getApiKey(),
+    'Content-Type': 'application/json',
+  };
+}
+
+async function get(path) {
+  const res = await fetch(`${BASE}${path}`, { headers: headers() });
+  if (!res.ok) {
+    const err = new Error(`HTTP ${res.status} — ${path}`);
+    err.status = res.status;
+    throw err;
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Endpoints
+// ---------------------------------------------------------------------------
+
+/** Returns all sensor readings keyed by sensor_id. */
+export function fetchSensors() {
+  return get('/sensors');
+}
+
+/** Returns the latest reading for one sensor (throws on 404/503). */
+export function fetchSensor(sensorId) {
+  return get(`/sensors/${sensorId}`);
+}
+
+/** Returns staleness and connectivity metadata for one sensor. */
+export function fetchSensorStatus(sensorId) {
+  return get(`/sensors/${sensorId}/status`);
+}
+
+/** Returns service health (broker connected, uptime). */
+export function fetchHealth() {
+  return get('/health');
+}
+
+/** Returns version info. */
+export function fetchVersion() {
+  return get('/version');
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket audio stream
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a WebSocket connection to the real-time audio stream.
+ *
+ * @param {(frame: object) => void} onFrame   - called for each parsed frame
+ * @param {(status: string) => void} onStatus - called with "connected" | "disconnected" | "error"
+ * @returns {{ close: () => void }}            - handle to close the connection
+ */
+export function createAudioStream(onFrame, onStatus) {
+  const key = getApiKey();
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const url = `${protocol}//${location.host}/ws/audio/stream?api_key=${encodeURIComponent(key)}`;
+
+  let ws = null;
+  let closed = false;
+  let retryDelay = 1000;
+
+  function connect() {
+    if (closed) return;
+    ws = new WebSocket(url);
+
+    ws.addEventListener('open', () => {
+      retryDelay = 1000;
+      onStatus('connected');
+    });
+
+    ws.addEventListener('message', (evt) => {
+      try {
+        onFrame(JSON.parse(evt.data));
+      } catch {
+        // malformed frame — ignore
+      }
+    });
+
+    ws.addEventListener('close', () => {
+      onStatus('disconnected');
+      if (!closed) {
+        setTimeout(connect, retryDelay);
+        retryDelay = Math.min(retryDelay * 2, 30_000);
+      }
+    });
+
+    ws.addEventListener('error', () => {
+      onStatus('error');
+    });
+  }
+
+  connect();
+
+  return {
+    close() {
+      closed = true;
+      ws?.close();
+    },
+  };
+}

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -1,5 +1,24 @@
 <script>
+  import { onMount } from 'svelte';
+  import { LOCATION } from '../api.js';
+
   let { version = '1.1.0', brokerConnected = false, onSettingsClick } = $props();
+
+  // Live clock — ticks every second
+  let now = $state(new Date());
+
+  onMount(() => {
+    const id = setInterval(() => { now = new Date(); }, 1000);
+    return () => clearInterval(id);
+  });
+
+  const timeStr = $derived(
+    now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
+  );
+  const dateStr = $derived(
+    now.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: '2-digit' })
+      .toUpperCase()
+  );
 </script>
 
 <header class="header pixel-border">
@@ -9,16 +28,26 @@
   </div>
 
   <div class="header-center">
-    <span class="tagline muted">HOME ENVIRONMENT MONITOR</span>
+    <div class="clock-block">
+      <span class="time glow">{timeStr}</span>
+      <span class="date muted">{dateStr}</span>
+    </div>
   </div>
 
   <div class="header-right">
-    <span
-      class="dot {brokerConnected ? 'dot--online' : 'dot--offline'}"
-      title={brokerConnected ? 'Broker connected' : 'Broker disconnected'}
-      aria-label={brokerConnected ? 'Broker connected' : 'Broker disconnected'}
-    >●</span>
-    <span class="broker-label muted">{brokerConnected ? 'MQTT OK' : 'MQTT DOWN'}</span>
+    <div class="coords muted" title="Location">
+      <span class="coords-label dimmer">◉</span>
+      <span>{LOCATION.label}</span>
+    </div>
+
+    <div class="broker-status">
+      <span
+        class="dot {brokerConnected ? 'dot--online' : 'dot--offline'}"
+        title={brokerConnected ? 'Broker connected' : 'Broker disconnected'}
+        aria-label={brokerConnected ? 'Broker connected' : 'Broker disconnected'}
+      >●</span>
+      <span class="broker-label muted">{brokerConnected ? 'MQTT OK' : 'NO MQTT'}</span>
+    </div>
 
     <button class="settings-btn" onclick={onSettingsClick} title="Settings" aria-label="Open settings">
       [⚙]
@@ -58,30 +87,62 @@
     font-size: 7px;
   }
 
+  /* Clock */
   .header-center {
     flex: 1;
-    text-align: center;
+    display: flex;
+    justify-content: center;
   }
 
-  .tagline {
+  .clock-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .time {
+    font-family: var(--font-vt);
+    font-size: 32px;
+    line-height: 1;
+    letter-spacing: 0.05em;
+  }
+
+  .date {
     font-family: var(--font-pixel);
     font-size: 7px;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
   }
 
+  /* Right section */
   .header-right {
     display: flex;
     align-items: center;
-    gap: var(--u3);
+    gap: var(--u4);
+  }
+
+  .coords {
+    display: flex;
+    align-items: center;
+    gap: var(--u2);
+    font-family: var(--font-pixel);
+    font-size: 7px;
+    letter-spacing: 0.04em;
+  }
+
+  .broker-status {
+    display: flex;
+    align-items: center;
+    gap: var(--u2);
+  }
+
+  .dot {
+    font-size: 14px;
   }
 
   .broker-label {
     font-family: var(--font-pixel);
     font-size: 7px;
-  }
-
-  .dot {
-    font-size: 16px;
   }
 
   .settings-btn {

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -1,0 +1,107 @@
+<script>
+  let { version = '1.1.0', brokerConnected = false, onSettingsClick } = $props();
+</script>
+
+<header class="header pixel-border">
+  <div class="header-left">
+    <span class="logo glow">ARKADIA</span>
+    <span class="version muted">v{version}</span>
+  </div>
+
+  <div class="header-center">
+    <span class="tagline muted">HOME ENVIRONMENT MONITOR</span>
+  </div>
+
+  <div class="header-right">
+    <span
+      class="dot {brokerConnected ? 'dot--online' : 'dot--offline'}"
+      title={brokerConnected ? 'Broker connected' : 'Broker disconnected'}
+      aria-label={brokerConnected ? 'Broker connected' : 'Broker disconnected'}
+    >●</span>
+    <span class="broker-label muted">{brokerConnected ? 'MQTT OK' : 'MQTT DOWN'}</span>
+
+    <button class="settings-btn" onclick={onSettingsClick} title="Settings" aria-label="Open settings">
+      [⚙]
+    </button>
+
+    <span class="cursor">█</span>
+  </div>
+</header>
+
+<style>
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--u4);
+    padding: var(--u3) var(--u6);
+    background: var(--bg-card);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    row-gap: var(--u2);
+  }
+
+  .header-left {
+    display: flex;
+    align-items: baseline;
+    gap: var(--u4);
+  }
+
+  .logo {
+    font-family: var(--font-pixel);
+    font-size: 16px;
+    letter-spacing: 0.15em;
+  }
+
+  .version {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+  }
+
+  .header-center {
+    flex: 1;
+    text-align: center;
+  }
+
+  .tagline {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+    letter-spacing: 0.08em;
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: var(--u3);
+  }
+
+  .broker-label {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+  }
+
+  .dot {
+    font-size: 16px;
+  }
+
+  .settings-btn {
+    background: transparent;
+    border: none;
+    color: var(--dim);
+    font-family: var(--font-pixel);
+    font-size: 9px;
+    cursor: pointer;
+    padding: 2px var(--u2);
+    transition: color 0.15s;
+  }
+
+  .settings-btn:hover {
+    color: var(--primary);
+    text-shadow: var(--glow);
+  }
+
+  .cursor {
+    font-size: 14px;
+    color: var(--accent);
+  }
+</style>

--- a/web/src/components/ReadingRow.svelte
+++ b/web/src/components/ReadingRow.svelte
@@ -1,0 +1,68 @@
+<script>
+  /**
+   * ReadingRow — one labeled sensor reading with a color-coded LED indicator.
+   *
+   * Props:
+   *   label   {string}  Reading name, e.g. "TEMPERATURE"
+   *   value   {string}  Formatted value string, e.g. "22.4"
+   *   unit    {string}  Unit suffix, e.g. "°C"
+   *   status  {string}  "good" | "ok" | "warn" | "danger" | "unknown"
+   *   sub     {string?} Optional second line (e.g. secondary value)
+   */
+  let { label = '', value = '—', unit = '', status = 'unknown', sub = '' } = $props();
+</script>
+
+<div class="reading-row">
+  <div class="reading-label">
+    <span class="indicator indicator--{status}" aria-label="Status: {status}"></span>
+    <span class="label">{label}</span>
+  </div>
+  <div class="reading-values">
+    <span class="reading-num reading--{status}">{value}<span class="reading-unit">{unit}</span></span>
+    {#if sub}
+      <span class="reading-sub muted">{sub}</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .reading-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .reading-label {
+    display: flex;
+    align-items: center;
+    gap: var(--u2);
+  }
+
+  .reading-values {
+    display: flex;
+    align-items: baseline;
+    gap: var(--u3);
+    padding-left: calc(10px + var(--u2)); /* align under label, past indicator */
+  }
+
+  .reading-num {
+    font-family: var(--font-vt);
+    font-size: 42px;
+    line-height: 1;
+    transition: color 0.4s;
+  }
+
+  .reading-unit {
+    font-family: var(--font-pixel);
+    font-size: 8px;
+    margin-left: 3px;
+    vertical-align: middle;
+    color: var(--dim);
+  }
+
+  .reading-sub {
+    font-family: var(--font-vt);
+    font-size: 20px;
+    line-height: 1;
+  }
+</style>

--- a/web/src/components/SensorCard.svelte
+++ b/web/src/components/SensorCard.svelte
@@ -1,0 +1,111 @@
+<script>
+  /**
+   * SensorCard — retro pixel-border panel for one sensor.
+   *
+   * Props:
+   *   title        {string}  Panel heading (e.g. "CLIMATE")
+   *   sensorId     {string}  Sensor ID for ARIA labels
+   *   connectivity {string}  "online" | "offline" | "unknown"
+   *   lastSeen     {string|null}  Human-readable last-seen string
+   *   stale        {boolean} Whether the reading is stale
+   */
+  let {
+    title = '',
+    sensorId = '',
+    connectivity = 'unknown',
+    lastSeen = null,
+    stale = false,
+    children,
+  } = $props();
+
+  const dotClass = $derived(
+    ({ online: 'dot--online', offline: 'dot--offline', unknown: 'dot--unknown' })[connectivity]
+    ?? 'dot--unknown'
+  );
+</script>
+
+<section
+  class="card pixel-border {stale ? 'pixel-border--warning' : ''}"
+  aria-label="{title} sensor panel"
+>
+  <!-- Card header strip -->
+  <div class="card-header">
+    <span class="card-title">{title}</span>
+    <div class="card-status">
+      {#if stale}
+        <span class="badge badge--stale">STALE</span>
+      {/if}
+      <span class="dot {dotClass}" title="Connectivity: {connectivity}" aria-label="Connectivity: {connectivity}">●</span>
+    </div>
+  </div>
+
+  <!-- Readings area — filled by parent via slot -->
+  <div class="card-body">
+    {@render children?.()}
+  </div>
+
+  <!-- Footer: last-seen timestamp -->
+  <div class="card-footer">
+    {#if lastSeen}
+      <span class="last-seen muted">{lastSeen}</span>
+    {:else}
+      <span class="last-seen dimmer">AWAITING DATA…</span>
+    {/if}
+    <span class="sensor-id dimmer">{sensorId}</span>
+  </div>
+</section>
+
+<style>
+  .card {
+    background: var(--bg-card);
+    display: flex;
+    flex-direction: column;
+    min-height: 260px;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--u3) var(--u4);
+    border-bottom: 1px solid var(--dimmer);
+    background: var(--bg-raised);
+    flex-shrink: 0;
+  }
+
+  .card-title {
+    font-family: var(--font-pixel);
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    color: var(--primary);
+  }
+
+  .card-status {
+    display: flex;
+    align-items: center;
+    gap: var(--u3);
+  }
+
+  .card-body {
+    flex: 1;
+    padding: var(--u5) var(--u4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--u4);
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--u2) var(--u4);
+    border-top: 1px solid var(--dimmer);
+    background: var(--bg-raised);
+    flex-shrink: 0;
+  }
+
+  .last-seen, .sensor-id {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+  }
+</style>

--- a/web/src/components/SettingsModal.svelte
+++ b/web/src/components/SettingsModal.svelte
@@ -1,0 +1,166 @@
+<script>
+  import { setApiKey } from '../api.js';
+
+  let { onSave } = $props();
+
+  let input = $state('');
+  let error = $state('');
+
+  function save() {
+    const key = input.trim();
+    if (!key) {
+      error = 'KEY CANNOT BE EMPTY';
+      return;
+    }
+    setApiKey(key);
+    onSave(key);
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Enter') save();
+  }
+</script>
+
+<div class="overlay">
+  <div class="modal pixel-border" role="dialog" aria-modal="true" aria-label="Enter API key">
+    <div class="modal-header">
+      <span class="glow">ARKADIA</span>
+    </div>
+
+    <div class="modal-body">
+      <p class="prompt">ENTER API KEY TO CONTINUE</p>
+      <p class="hint muted">Your key is stored only in this browser.</p>
+
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        class="key-input pixel-border"
+        type="password"
+        placeholder="••••••••••••••••"
+        bind:value={input}
+        onkeydown={handleKeydown}
+        autofocus
+        spellcheck="false"
+        autocomplete="off"
+      />
+
+      {#if error}
+        <p class="error danger">{error}</p>
+      {/if}
+
+      <button class="btn pixel-border" onclick={save}>
+        [ CONNECT ]
+      </button>
+    </div>
+
+    <div class="modal-footer muted">
+      Set <code>MONITOR_API_KEY</code> in <code>/etc/home-monitor.env</code>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(13, 2, 8, 0.95);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 8000;
+  }
+
+  .modal {
+    width: min(480px, 92vw);
+    background: var(--bg-card);
+    padding: var(--u6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--u5);
+  }
+
+  .modal-header {
+    font-family: var(--font-pixel);
+    font-size: 18px;
+    text-align: center;
+    letter-spacing: 0.1em;
+    padding-bottom: var(--u4);
+    border-bottom: 1px solid var(--dimmer);
+  }
+
+  .modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u4);
+  }
+
+  .prompt {
+    font-family: var(--font-pixel);
+    font-size: 9px;
+    color: var(--primary);
+    letter-spacing: 0.05em;
+  }
+
+  .hint {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+    line-height: 1.8;
+  }
+
+  .key-input {
+    width: 100%;
+    background: var(--bg);
+    color: var(--primary);
+    font-family: var(--font-vt);
+    font-size: 24px;
+    padding: var(--u3) var(--u4);
+    outline: none;
+    caret-color: var(--accent);
+  }
+
+  .key-input:focus {
+    --border-color: var(--accent);
+    box-shadow: var(--glow), var(--border-w) var(--border-w) 0 var(--dimmer);
+  }
+
+  .key-input::placeholder {
+    color: var(--dimmer);
+  }
+
+  .error {
+    font-family: var(--font-pixel);
+    font-size: 8px;
+  }
+
+  .btn {
+    align-self: flex-end;
+    background: transparent;
+    color: var(--primary);
+    font-family: var(--font-pixel);
+    font-size: 9px;
+    padding: var(--u3) var(--u5);
+    cursor: pointer;
+    transition: background 0.1s;
+    letter-spacing: 0.05em;
+  }
+
+  .btn:hover, .btn:focus {
+    background: var(--muted);
+    outline: none;
+    text-shadow: var(--glow);
+  }
+
+  .modal-footer {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+    line-height: 2;
+    padding-top: var(--u4);
+    border-top: 1px solid var(--dimmer);
+    text-align: center;
+  }
+
+  code {
+    color: var(--accent);
+    font-family: var(--font-vt);
+    font-size: 16px;
+  }
+</style>

--- a/web/src/components/StatusBar.svelte
+++ b/web/src/components/StatusBar.svelte
@@ -1,0 +1,50 @@
+<script>
+  let { lastPoll = null, pollError = false, brokerConnected = false } = $props();
+</script>
+
+<footer class="status-bar">
+  <span class="item">
+    <span class="dot {brokerConnected ? 'dot--online' : 'dot--offline'}">●</span>
+    <span class="muted">{brokerConnected ? 'BROKER OK' : 'BROKER OFFLINE'}</span>
+  </span>
+
+  <span class="item">
+    {#if pollError}
+      <span class="danger">▲ API ERROR</span>
+    {:else if lastPoll}
+      <span class="muted">LAST POLL: {lastPoll}</span>
+    {:else}
+      <span class="dimmer">POLLING…</span>
+    {/if}
+  </span>
+
+  <span class="item">
+    <span class="dimmer">ARKADIA v1.1.0</span>
+  </span>
+</footer>
+
+<style>
+  .status-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--u4);
+    padding: var(--u2) var(--u6);
+    border-top: 1px solid var(--dimmer);
+    background: var(--bg-card);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .item {
+    display: flex;
+    align-items: center;
+    gap: var(--u2);
+    font-family: var(--font-pixel);
+    font-size: 7px;
+  }
+
+  .dot {
+    font-size: 10px;
+  }
+</style>

--- a/web/src/components/StatusBar.svelte
+++ b/web/src/components/StatusBar.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { LOCATION } from '../api.js';
   let { lastPoll = null, pollError = false, brokerConnected = false } = $props();
 </script>
 
@@ -18,8 +19,9 @@
     {/if}
   </span>
 
-  <span class="item">
-    <span class="dimmer">ARKADIA v1.1.0</span>
+  <span class="item coords">
+    <span class="dimmer">◉</span>
+    <span class="muted">{LOCATION.label}</span>
   </span>
 </footer>
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,0 +1,7 @@
+import '../src/styles/global.css';
+import App from './App.svelte';
+import { mount } from 'svelte';
+
+const app = mount(App, { target: document.getElementById('app') });
+
+export default app;

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -227,6 +227,41 @@ body::after {
 }
 
 /* ---------------------------------------------------------
+   Reading status — color indicator blocks
+   Used by ReadingRow and canvas visualizers.
+   --------------------------------------------------------- */
+:root {
+  --status-good:    #00ff41;   /* in-range */
+  --status-ok:      #aaff00;   /* acceptable edge */
+  --status-warn:    #ffb000;   /* outside comfort zone */
+  --status-danger:  #ff3131;   /* unhealthy / extreme */
+  --status-unknown: #555555;
+}
+
+/* Inline LED-style indicator square */
+.indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  /* default to unknown */
+  background: var(--status-unknown);
+}
+
+.indicator--good    { background: var(--status-good);   box-shadow: 0 0 6px var(--status-good);   }
+.indicator--ok      { background: var(--status-ok);     box-shadow: 0 0 6px var(--status-ok);     }
+.indicator--warn    { background: var(--status-warn);   box-shadow: 0 0 6px var(--status-warn);   }
+.indicator--danger  { background: var(--status-danger); box-shadow: 0 0 6px var(--status-danger); }
+.indicator--unknown { background: var(--status-unknown); }
+
+/* Value text tinting */
+.reading--good    { color: var(--status-good);   }
+.reading--ok      { color: var(--status-ok);     }
+.reading--warn    { color: var(--status-warn);   }
+.reading--danger  { color: var(--status-danger); }
+.reading--unknown { color: var(--dim); }
+
+/* ---------------------------------------------------------
    Scrollbar
    --------------------------------------------------------- */
 ::-webkit-scrollbar        { width: 6px; background: var(--bg); }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1,0 +1,234 @@
+/* =========================================================
+   Arkadia — Retro Green Terminal Design System
+   ========================================================= */
+
+/* ---------------------------------------------------------
+   Google Fonts are loaded in index.html.  These fallbacks
+   ensure legibility if the CDN is unreachable.
+   --------------------------------------------------------- */
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap');
+
+/* ---------------------------------------------------------
+   CSS Custom Properties
+   --------------------------------------------------------- */
+:root {
+  /* Palette */
+  --bg:         #0d0208;
+  --bg-card:    #0f0d0f;
+  --bg-raised:  #141414;
+  --primary:    #00ff41;
+  --accent:     #39ff14;
+  --dim:        #00a829;
+  --dimmer:     #005c17;
+  --muted:      #1e3a1e;
+  --danger:     #ff3131;
+  --warning:    #ffb000;
+  --info:       #00cfff;
+
+  /* Status dots */
+  --dot-online:  #00ff41;
+  --dot-offline: #ff3131;
+  --dot-unknown: #555;
+
+  /* Typography */
+  --font-pixel: 'Press Start 2P', 'Courier New', monospace;
+  --font-vt:    'VT323', 'Courier New', monospace;
+
+  /* Scale — base unit is 4 px */
+  --u1: 4px;
+  --u2: 8px;
+  --u3: 12px;
+  --u4: 16px;
+  --u5: 20px;
+  --u6: 24px;
+  --u8: 32px;
+  --u10: 40px;
+
+  /* Border */
+  --border-color: var(--primary);
+  --border-w: 2px;
+
+  /* Pixel glow */
+  --glow: 0 0 8px var(--primary), 0 0 2px var(--accent);
+  --glow-dim: 0 0 4px var(--dimmer);
+}
+
+/* ---------------------------------------------------------
+   Reset & Base
+   --------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+  overflow-x: hidden;
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--primary);
+  font-family: var(--font-pixel);
+  font-size: 10px;
+  line-height: 1.6;
+  /* Subtle screen flicker */
+  animation: flicker 8s infinite;
+}
+
+#app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+/* ---------------------------------------------------------
+   Scanline overlay
+   --------------------------------------------------------- */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9000;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent         0px,
+    transparent         3px,
+    rgba(0, 0, 0, 0.18) 3px,
+    rgba(0, 0, 0, 0.18) 4px
+  );
+}
+
+/* ---------------------------------------------------------
+   Screen flicker
+   --------------------------------------------------------- */
+@keyframes flicker {
+  0%,  19%,  21%,  23%,  25%,  54%,  56%,  100% { opacity: 1; }
+  20%, 24%,  55% { opacity: 0.92; }
+}
+
+/* ---------------------------------------------------------
+   Blinking cursor
+   --------------------------------------------------------- */
+.cursor {
+  display: inline-block;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+/* ---------------------------------------------------------
+   Pixel border helper  (add .pixel-border to any element)
+   --------------------------------------------------------- */
+.pixel-border {
+  border: var(--border-w) solid var(--border-color);
+  box-shadow:
+    var(--border-w) var(--border-w) 0 var(--dimmer),
+    inset 0 0 0 1px var(--dimmer);
+}
+
+.pixel-border--danger {
+  --border-color: var(--danger);
+}
+
+.pixel-border--warning {
+  --border-color: var(--warning);
+}
+
+/* ---------------------------------------------------------
+   Typography helpers
+   --------------------------------------------------------- */
+.font-vt {
+  font-family: var(--font-vt);
+  font-size: 28px;
+  line-height: 1;
+}
+
+.font-vt-lg {
+  font-family: var(--font-vt);
+  font-size: 48px;
+  line-height: 1;
+}
+
+.font-vt-xl {
+  font-family: var(--font-vt);
+  font-size: 64px;
+  line-height: 1;
+}
+
+.label {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  letter-spacing: 0.05em;
+  color: var(--dim);
+  text-transform: uppercase;
+}
+
+.value {
+  font-family: var(--font-vt);
+  font-size: 36px;
+  color: var(--primary);
+  line-height: 1;
+}
+
+/* ---------------------------------------------------------
+   Connectivity dot
+   --------------------------------------------------------- */
+.dot {
+  display: inline-block;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.dot--online  { color: var(--dot-online);  text-shadow: 0 0 6px var(--dot-online); }
+.dot--offline { color: var(--dot-offline); text-shadow: 0 0 6px var(--dot-offline); }
+.dot--unknown { color: var(--dot-unknown); }
+
+/* ---------------------------------------------------------
+   Status badge
+   --------------------------------------------------------- */
+.badge {
+  display: inline-block;
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  padding: 2px var(--u2);
+  border: 1px solid currentColor;
+}
+
+.badge--stale   { color: var(--warning); border-color: var(--warning); }
+.badge--offline { color: var(--danger);  border-color: var(--danger);  }
+.badge--ok      { color: var(--dim);     border-color: var(--dimmer);  }
+
+/* ---------------------------------------------------------
+   Utility
+   --------------------------------------------------------- */
+.muted  { color: var(--dim); }
+.dimmer { color: var(--dimmer); }
+.danger { color: var(--danger); }
+.warning { color: var(--warning); }
+
+.glow {
+  text-shadow: var(--glow);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* ---------------------------------------------------------
+   Scrollbar
+   --------------------------------------------------------- */
+::-webkit-scrollbar        { width: 6px; background: var(--bg); }
+::-webkit-scrollbar-thumb  { background: var(--dimmer); border-radius: 0; }
+::-webkit-scrollbar-thumb:hover { background: var(--dim); }

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+  server: {
+    port: 5173,
+    // Proxy API and WebSocket calls to the FastAPI backend during development.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+      '/ws': {
+        target: 'ws://localhost:8000',
+        ws: true,
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Initializes the `web/` Vite + Svelte project and builds every visual building block. Also updates `docs/dev-plan.md` with the full web app breakdown (PRs 9–12).

---

### Stack

| | |
|--|--|
| Framework | Svelte 5 + Vite 8 |
| Fonts | Press Start 2P (pixel headings), VT323 (numeric readouts) |
| Palette | Green terminal — `#0d0208` bg / `#00ff41` primary / `#39ff14` accent |
| Build output | `web/dist/` — 52 kB JS, 11 kB CSS, zero warnings |

### Components & modules

| File | Purpose |
|------|---------|
| `src/styles/global.css` | CSS variables, pixel-border, scanline overlay, screen flicker, status-color system (`--status-good/ok/warn/danger`) |
| `src/api.js` | API client, `LOCATION` constant, `INMP441_OFFSET`/`dbfsToDB()`, `statusFor()` + `THRESHOLDS` for all five measurements |
| `src/components/ReadingRow.svelte` | Label + LED indicator square + VT323 value + unit; status drives indicator color and value tint |
| `src/components/Header.svelte` | Logo, live clock (ticks every second), date, hardcoded coordinates, broker dot, blinking cursor |
| `src/components/SensorCard.svelte` | Pixel-border panel, connectivity dot, stale badge, last-seen footer |
| `src/components/StatusBar.svelte` | Poll timestamp, broker status, coordinates |
| `src/components/SettingsModal.svelte` | API key entry (persisted to `localStorage`) |
| `src/App.svelte` | Boot typewriter, settings gate, three-panel grid; Climate/Air use `ReadingRow`; Audio has EQ bar placeholder with colored tops + SVG waveform placeholder + dBFS + ~dB SPL |

### Walkthrough

[arkadia_dashboard_pr9_updated.mp4](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farkadia_dashboard_pr9_updated.mp4)

[Full updated dashboard](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_updated.webp)

[Audio panel — EQ bars with colored tops and waveform placeholder](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudio_panel_detail.webp)

---

**Testing**
- ✅ `npm run build` — zero errors, zero warnings (52 kB JS / 11 kB CSS)
- ✅ `npm run dev` serves at `http://localhost:5173`
- ✅ Settings modal blocks on first load; key saved to `localStorage`
- ✅ Boot typewriter sequence → dashboard fade-in
- ✅ Live clock ticks every second; date and coordinates display correctly
- ✅ Three `SensorCard` panels with `ReadingRow` grey LED indicators (unknown status)
- ✅ EQ bars show colored top-caps (good=green, ok=lime, warn=amber, danger=red)
- ✅ Waveform oscilloscope placeholder visible in Audio panel
- ✅ Level row shows both `dBFS` and `~dB SPL` sub-value
- ✅ Scanline overlay, screen flicker, blinking cursor visible


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

