### PR TITLE
feat(web): wire climate and air quality panels to live API (PR 10)

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,22 +1,34 @@
 <script>
   import { onMount } from 'svelte';
-  import { getApiKey, dbfsToDB } from './api.js';
-  import Header from './components/Header.svelte';
-  import SensorCard from './components/SensorCard.svelte';
-  import StatusBar from './components/StatusBar.svelte';
+  import {
+    getApiKey,
+    dbfsToDB,
+    statusFor,
+    THRESHOLDS,
+    fetchHealth,
+    fetchSensors,
+    fetchSensorStatus,
+    formatRelativeTime,
+    formatHMS,
+  } from './api.js';
+
+  import Header        from './components/Header.svelte';
+  import SensorCard    from './components/SensorCard.svelte';
+  import StatusBar     from './components/StatusBar.svelte';
   import SettingsModal from './components/SettingsModal.svelte';
-  import ReadingRow from './components/ReadingRow.svelte';
+  import ReadingRow    from './components/ReadingRow.svelte';
+  import TemperatureGauge from './components/TemperatureGauge.svelte';
+  import BarMeter      from './components/BarMeter.svelte';
 
   // ---------------------------------------------------------------------------
   // Settings gate
   // ---------------------------------------------------------------------------
-  let apiKey = $state(getApiKey());
+  let apiKey      = $state(getApiKey());
   let showSettings = $state(!getApiKey());
 
   function handleSave(key) {
     apiKey = key;
     showSettings = false;
-    // Re-trigger boot when key is set for the first time
     startBoot();
   }
 
@@ -35,18 +47,16 @@
     '',
   ];
 
-  let booting = $state(true);
+  let booting   = $state(true);
   let bootLines = $state([]);
-  let bootDone = $state(false);
+  let bootDone  = $state(false);
 
   function startBoot() {
-    booting = true;
+    booting   = true;
     bootLines = [];
-    bootDone = false;
+    bootDone  = false;
 
-    let lineIdx = 0;
-    let charIdx = 0;
-    let current = '';
+    let lineIdx = 0, charIdx = 0, current = '';
 
     function tick() {
       if (lineIdx >= BOOT_LINES.length) {
@@ -62,39 +72,120 @@
         setTimeout(tick, 28);
       } else {
         bootLines = [...bootLines.slice(0, lineIdx), current];
-        lineIdx++;
-        charIdx = 0;
-        current = '';
+        lineIdx++; charIdx = 0; current = '';
         setTimeout(tick, lineIdx === BOOT_LINES.length ? 400 : 80);
       }
     }
-
     tick();
   }
 
   // ---------------------------------------------------------------------------
-  // Placeholder sensor state (data wired in PR 10/11)
+  // Sensor state
   // ---------------------------------------------------------------------------
-  // These will be replaced by real API polling in subsequent PRs.
-  const sensors = {
-    bme280:  { title: 'CLIMATE',     connectivity: 'unknown', lastSeen: null, stale: false },
-    scd40:   { title: 'AIR QUALITY', connectivity: 'unknown', lastSeen: null, stale: false },
-    inmp441: { title: 'AUDIO',       connectivity: 'unknown', lastSeen: null, stale: false },
-  };
 
+  function makeSensor(title) {
+    return { title, connectivity: 'unknown', lastSeen: null, stale: false, readings: null };
+  }
+
+  let bme280  = $state(makeSensor('CLIMATE'));
+  let scd40   = $state(makeSensor('AIR QUALITY'));
+  let inmp441 = $state(makeSensor('AUDIO'));
+
+  // Derived display values for BME280
+  const tempC  = $derived(bme280.readings?.temperature_c ?? null);
+  const humPct = $derived(bme280.readings?.humidity_pct  ?? null);
+  const presHpa = $derived(bme280.readings?.pressure_hpa ?? null);
+
+  const tempStatus = $derived(statusFor(tempC,   THRESHOLDS.temperature_c));
+  const humStatus  = $derived(statusFor(humPct,  THRESHOLDS.humidity_pct));
+  const presStatus = $derived(statusFor(presHpa, THRESHOLDS.pressure_hpa));
+
+  // Derived display values for SCD40
+  const co2Ppm     = $derived(scd40.readings?.co2_ppm      ?? null);
+  const scdTempC   = $derived(scd40.readings?.temperature_c ?? null);
+  const scdHumPct  = $derived(scd40.readings?.humidity_pct  ?? null);
+
+  const co2Status     = $derived(statusFor(co2Ppm,    THRESHOLDS.co2_ppm));
+  const scdTempStatus = $derived(statusFor(scdTempC,  THRESHOLDS.temperature_c));
+  const scdHumStatus  = $derived(statusFor(scdHumPct, THRESHOLDS.humidity_pct));
+
+  // ---------------------------------------------------------------------------
+  // Polling
+  // ---------------------------------------------------------------------------
   let brokerConnected = $state(false);
-  let lastPoll = $state(null);
-  let pollError = $state(false);
+  let lastPoll        = $state(null);
+  let pollError       = $state(false);
+  let retryDelay      = 5_000;
+  let pollTimer       = null;
+
+  async function poll() {
+    const [healthRes, sensorsRes, s1Res, s2Res, s3Res] = await Promise.allSettled([
+      fetchHealth(),
+      fetchSensors(),
+      fetchSensorStatus('bme280'),
+      fetchSensorStatus('scd40'),
+      fetchSensorStatus('inmp441'),
+    ]);
+
+    // Broker health
+    if (healthRes.status === 'fulfilled') {
+      brokerConnected = healthRes.value.broker_connected;
+    }
+
+    // Latest readings
+    if (sensorsRes.status === 'fulfilled') {
+      const d = sensorsRes.value;
+      if (d.bme280)  bme280.readings  = d.bme280.readings;
+      if (d.scd40)   scd40.readings   = d.scd40.readings;
+      if (d.inmp441) inmp441.readings = d.inmp441.readings;
+    }
+
+    // Per-sensor status (connectivity + staleness + last_seen)
+    const applyStatus = (res, sensor) => {
+      if (res.status === 'fulfilled') {
+        sensor.connectivity = res.value.connectivity;
+        sensor.stale        = res.value.stale;
+        sensor.lastSeen     = formatRelativeTime(res.value.last_seen);
+      }
+    };
+    applyStatus(s1Res, bme280);
+    applyStatus(s2Res, scd40);
+    applyStatus(s3Res, inmp441);
+
+    // Mark overall poll result
+    const anyFailed = [healthRes, sensorsRes].some(r => r.status === 'rejected');
+    if (anyFailed) {
+      pollError  = true;
+      retryDelay = Math.min(retryDelay * 2, 60_000);
+    } else {
+      pollError  = false;
+      retryDelay = 30_000;
+      lastPoll   = formatHMS(new Date());
+    }
+  }
+
+  function schedulePoll() {
+    poll().finally(() => {
+      pollTimer = setTimeout(schedulePoll, retryDelay);
+    });
+  }
 
   // ---------------------------------------------------------------------------
   // Lifecycle
   // ---------------------------------------------------------------------------
   onMount(() => {
     if (apiKey) startBoot();
+    // Start polling after the boot animation, or immediately if already loaded.
+    const delay = apiKey ? 1800 : 0;
+    pollTimer = setTimeout(schedulePoll, delay);
+
+    return () => {
+      if (pollTimer) clearTimeout(pollTimer);
+    };
   });
 </script>
 
-<!-- Settings modal blocks everything until key is entered -->
+<!-- Settings modal -->
 {#if showSettings}
   <SettingsModal onSave={handleSave} />
 {/if}
@@ -113,50 +204,110 @@
   </div>
 {/if}
 
-<!-- Main dashboard (rendered behind boot overlay for instant display after fade) -->
+<!-- Main dashboard -->
 {#if !showSettings}
   <div class="layout" class:hidden={booting}>
-    <Header
-      brokerConnected={brokerConnected}
-      onSettingsClick={openSettings}
-    />
+    <Header brokerConnected={brokerConnected} onSettingsClick={openSettings} />
 
     <main class="dashboard">
-      <!-- Climate panel -->
+
+      <!-- ── CLIMATE (BME280) ─────────────────────────────────────────── -->
       <SensorCard
-        title={sensors.bme280.title}
+        title={bme280.title}
         sensorId="bme280"
-        connectivity={sensors.bme280.connectivity}
-        lastSeen={sensors.bme280.lastSeen}
-        stale={sensors.bme280.stale}
+        connectivity={bme280.connectivity}
+        lastSeen={bme280.lastSeen}
+        stale={bme280.stale}
       >
-        <ReadingRow label="TEMPERATURE" value="—.—" unit="°C"  status="unknown" />
-        <ReadingRow label="HUMIDITY"    value="——"  unit="%"    status="unknown" />
-        <ReadingRow label="PRESSURE"    value="————" unit=" hPa" status="unknown" />
-        <p class="coming-soon muted">LIVE DATA IN PR 10</p>
+        <div class="climate-layout">
+          <TemperatureGauge value={tempC} />
+          <div class="climate-readings">
+            <ReadingRow
+              label="TEMPERATURE"
+              value={tempC != null ? tempC.toFixed(1) : '—.—'}
+              unit="°C"
+              status={tempStatus}
+            />
+            <ReadingRow
+              label="HUMIDITY"
+              value={humPct != null ? humPct.toFixed(0) : '——'}
+              unit="%"
+              status={humStatus}
+            />
+            <ReadingRow
+              label="PRESSURE"
+              value={presHpa != null ? presHpa.toFixed(0) : '————'}
+              unit=" hPa"
+              status={presStatus}
+            />
+          </div>
+        </div>
       </SensorCard>
 
-      <!-- Air quality panel -->
+      <!-- ── AIR QUALITY (SCD40) ─────────────────────────────────────── -->
       <SensorCard
-        title={sensors.scd40.title}
+        title={scd40.title}
         sensorId="scd40"
-        connectivity={sensors.scd40.connectivity}
-        lastSeen={sensors.scd40.lastSeen}
-        stale={sensors.scd40.stale}
+        connectivity={scd40.connectivity}
+        lastSeen={scd40.lastSeen}
+        stale={scd40.stale}
       >
-        <ReadingRow label="CO₂"         value="————" unit=" ppm" status="unknown" />
-        <ReadingRow label="TEMPERATURE" value="—.—"  unit="°C"  status="unknown" />
-        <ReadingRow label="HUMIDITY"    value="——"   unit="%"    status="unknown" />
-        <p class="coming-soon muted">LIVE DATA IN PR 10</p>
+        <!-- CO₂ prominently with bar -->
+        <div class="co2-block">
+          <ReadingRow
+            label="CO₂"
+            value={co2Ppm != null ? co2Ppm.toFixed(0) : '————'}
+            unit=" ppm"
+            status={co2Status}
+          />
+          <BarMeter
+            value={co2Ppm}
+            min={400}
+            max={2000}
+            blocks={12}
+            thresholds={THRESHOLDS.co2_ppm}
+            label="CO₂ level bar"
+          />
+          <div class="co2-scale">
+            <span class="dimmer">400</span>
+            <span class="dimmer">GOOD</span>
+            <span class="dimmer">WARN</span>
+            <span class="dimmer">2000</span>
+          </div>
+        </div>
+
+        <!-- Secondary: temperature + humidity from SCD40 -->
+        {#if scdTempC != null || scdHumPct != null}
+          <div class="air-secondary">
+            {#if scdTempC != null}
+              <ReadingRow
+                label="TEMPERATURE"
+                value={scdTempC.toFixed(1)}
+                unit="°C"
+                status={scdTempStatus}
+              />
+            {/if}
+            {#if scdHumPct != null}
+              <ReadingRow
+                label="HUMIDITY"
+                value={scdHumPct.toFixed(0)}
+                unit="%"
+                status={scdHumStatus}
+              />
+            {/if}
+          </div>
+        {:else}
+          <p class="awaiting muted">AWAITING SENSOR DATA…</p>
+        {/if}
       </SensorCard>
 
-      <!-- Audio panel -->
+      <!-- ── AUDIO (INMP441) — placeholder until PR 11 ─────────────── -->
       <SensorCard
-        title={sensors.inmp441.title}
+        title={inmp441.title}
         sensorId="inmp441"
-        connectivity={sensors.inmp441.connectivity}
-        lastSeen={sensors.inmp441.lastSeen}
-        stale={sensors.inmp441.stale}
+        connectivity={inmp441.connectivity}
+        lastSeen={inmp441.lastSeen}
+        stale={inmp441.stale}
       >
         <!-- EQ bar placeholder with colored tops -->
         <div class="eq-placeholder" aria-label="Equalizer placeholder">
@@ -177,85 +328,54 @@
         </div>
 
         <!-- Waveform oscilloscope placeholder -->
-        <div class="waveform-placeholder" aria-label="Waveform oscilloscope placeholder">
+        <div class="waveform-placeholder">
           <span class="label">WAVEFORM</span>
           <div class="waveform-screen">
             <svg width="100%" height="48" preserveAspectRatio="none" aria-hidden="true">
-              <!-- idle flat line with slight noise -->
               <polyline
                 points="0,24 20,24 40,23 60,25 80,24 100,24 120,23 140,25 160,24 180,24 200,23 220,25 240,24 260,24 280,23 300,25 320,24"
-                fill="none"
-                stroke="var(--dimmer)"
-                stroke-width="1.5"
+                fill="none" stroke="var(--dimmer)" stroke-width="1.5"
               />
             </svg>
           </div>
         </div>
 
-        <!-- Level readings: dBFS + estimated dB SPL -->
-        <ReadingRow
-          label="LEVEL"
-          value="——"
-          unit=" dBFS"
-          status="unknown"
-          sub="~—— dB SPL"
-        />
+        {#if inmp441.readings}
+          {@const dbfs = inmp441.readings.db_level}
+          <ReadingRow
+            label="LEVEL"
+            value={dbfs.toFixed(1)}
+            unit=" dBFS"
+            status={statusFor(dbfs, THRESHOLDS.db_level)}
+            sub={`~${dbfsToDB(dbfs).toFixed(1)} dB SPL`}
+          />
+        {:else}
+          <ReadingRow label="LEVEL" value="——" unit=" dBFS" status="unknown" sub="~—— dB SPL" />
+        {/if}
+
         <p class="coming-soon muted">LIVE AUDIO IN PR 11</p>
       </SensorCard>
     </main>
 
-    <StatusBar
-      lastPoll={lastPoll}
-      pollError={pollError}
-      brokerConnected={brokerConnected}
-    />
+    <StatusBar lastPoll={lastPoll} pollError={pollError} brokerConnected={brokerConnected} />
   </div>
 {/if}
 
 <style>
   /* Boot screen */
   .boot-screen {
-    position: fixed;
-    inset: 0;
+    position: fixed; inset: 0;
     background: var(--bg);
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: flex; align-items: center; justify-content: center;
     z-index: 7000;
   }
+  .boot-lines { display: flex; flex-direction: column; gap: var(--u3); padding: var(--u8); }
+  .boot-line  { font-family: var(--font-pixel); font-size: 10px; color: var(--primary); letter-spacing: 0.05em; white-space: pre; }
+  .dim        { color: var(--dim); margin-right: var(--u2); }
 
-  .boot-lines {
-    display: flex;
-    flex-direction: column;
-    gap: var(--u3);
-    padding: var(--u8);
-  }
-
-  .boot-line {
-    font-family: var(--font-pixel);
-    font-size: 10px;
-    color: var(--primary);
-    letter-spacing: 0.05em;
-    white-space: pre;
-  }
-
-  .dim {
-    color: var(--dim);
-    margin-right: var(--u2);
-  }
-
-  /* Main layout */
-  .layout {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-    transition: opacity 0.3s;
-  }
-
-  .layout.hidden {
-    opacity: 0;
-    pointer-events: none;
-  }
+  /* Layout */
+  .layout { display: flex; flex-direction: column; min-height: 100vh; transition: opacity 0.3s; }
+  .layout.hidden { opacity: 0; pointer-events: none; }
 
   /* Dashboard grid */
   .dashboard {
@@ -266,71 +386,74 @@
     padding: var(--u5) var(--u6);
     align-items: start;
   }
+  @media (max-width: 900px) { .dashboard { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 580px) { .dashboard { grid-template-columns: 1fr; } }
 
-  @media (max-width: 900px) {
-    .dashboard {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
-
-  @media (max-width: 580px) {
-    .dashboard {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .coming-soon {
-    font-family: var(--font-pixel);
-    font-size: 7px;
-    margin-top: var(--u2);
-    padding-top: var(--u3);
-    border-top: 1px solid var(--dimmer);
-  }
-
-  /* EQ bar placeholder */
-  .eq-placeholder {
+  /* Climate panel layout */
+  .climate-layout {
     display: flex;
-    align-items: flex-end;
-    gap: 4px;
-    height: 90px;
-    padding-bottom: 0;
-    border-bottom: 1px solid var(--dimmer);
-    margin-bottom: var(--u2);
+    gap: var(--u5);
+    align-items: flex-start;
   }
-
-  .eq-col {
+  .climate-readings {
     flex: 1;
-    min-width: 8px;
-    background: var(--dim);
-    position: relative;
     display: flex;
     flex-direction: column;
-    justify-content: flex-start;
+    gap: var(--u4);
   }
 
-  /* Top 3-pixel cap on each EQ bar — color indicates amplitude */
-  .eq-top {
-    height: 4px;
-    width: 100%;
-    flex-shrink: 0;
+  /* CO₂ block */
+  .co2-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u3);
+    padding-bottom: var(--u4);
+    border-bottom: 1px solid var(--dimmer);
+  }
+  .co2-scale {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-pixel);
+    font-size: 6px;
+    color: var(--dimmer);
+    margin-top: -2px;
+  }
+  .air-secondary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u4);
+    padding-top: var(--u2);
+  }
+  .awaiting {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+    padding-top: var(--u2);
   }
 
+  /* Audio panel EQ placeholder */
+  .eq-placeholder {
+    display: flex; align-items: flex-end; gap: 4px;
+    height: 90px; border-bottom: 1px solid var(--dimmer); margin-bottom: var(--u2);
+  }
+  .eq-col {
+    flex: 1; min-width: 8px; background: var(--dim);
+    position: relative; display: flex; flex-direction: column; justify-content: flex-start;
+  }
+  .eq-top { height: 4px; width: 100%; flex-shrink: 0; }
   .eq-top--good   { background: var(--status-good);   box-shadow: 0 0 4px var(--status-good);   }
   .eq-top--ok     { background: var(--status-ok);     box-shadow: 0 0 4px var(--status-ok);     }
   .eq-top--warn   { background: var(--status-warn);   box-shadow: 0 0 4px var(--status-warn);   }
   .eq-top--danger { background: var(--status-danger); box-shadow: 0 0 4px var(--status-danger); }
 
-  /* Waveform oscilloscope placeholder */
-  .waveform-placeholder {
-    display: flex;
-    flex-direction: column;
-    gap: var(--u2);
+  /* Waveform placeholder */
+  .waveform-placeholder { display: flex; flex-direction: column; gap: var(--u2); }
+  .waveform-screen {
+    background: var(--bg); border: 1px solid var(--dimmer); padding: var(--u2);
+    box-shadow: inset 0 0 8px rgba(0,255,65,0.04);
   }
 
-  .waveform-screen {
-    background: var(--bg);
-    border: 1px solid var(--dimmer);
-    padding: var(--u2);
-    box-shadow: inset 0 0 8px rgba(0, 255, 65, 0.04);
+  .coming-soon {
+    font-family: var(--font-pixel); font-size: 7px;
+    margin-top: var(--u2); padding-top: var(--u3); border-top: 1px solid var(--dimmer);
   }
 </style>

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -97,6 +97,33 @@ export const THRESHOLDS = {
   ],
 };
 
+// ---------------------------------------------------------------------------
+// Time formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a human-readable relative time string for an ISO 8601 timestamp.
+ * e.g. "just now", "14s ago", "2m ago", "1h ago"
+ */
+export function formatRelativeTime(isoString) {
+  if (!isoString) return null;
+  const diffMs = Date.now() - new Date(isoString).getTime();
+  const s = Math.max(0, Math.floor(diffMs / 1000));
+  if (s < 10)  return 'just now';
+  if (s < 60)  return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60)  return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
+/**
+ * Format a Date as HH:MM:SS.
+ */
+export function formatHMS(date) {
+  return date.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
 const BASE = '/api';
 const KEY_STORAGE = 'arkadia_api_key';
 

--- a/web/src/components/BarMeter.svelte
+++ b/web/src/components/BarMeter.svelte
@@ -1,0 +1,86 @@
+<script>
+  /**
+   * BarMeter — a horizontal row of discrete pixel blocks.
+   *
+   * The number of filled blocks is proportional to (value - min) / (max - min).
+   * All filled blocks share the same color, determined by statusFor(value, thresholds).
+   *
+   * Props:
+   *   value       {number|null}
+   *   min         {number}       Default 0
+   *   max         {number}       Default 100
+   *   blocks      {number}       Number of discrete segments (default 12)
+   *   thresholds  {Array}        statusFor-compatible range table (optional)
+   *   label       {string}       Accessible label
+   */
+  import { statusFor } from '../api.js';
+
+  let {
+    value = null,
+    min = 0,
+    max = 100,
+    blocks = 12,
+    thresholds = null,
+    label = 'Bar meter',
+  } = $props();
+
+  const STATUS_COLORS = {
+    good:    'var(--status-good)',
+    ok:      'var(--status-ok)',
+    warn:    'var(--status-warn)',
+    danger:  'var(--status-danger)',
+    unknown: 'var(--dimmer)',
+  };
+
+  const filledCount = $derived.by(() => {
+    if (value == null) return 0;
+    const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)));
+    return Math.round(ratio * blocks);
+  });
+
+  const status = $derived(
+    thresholds && value != null ? statusFor(value, thresholds) : 'unknown'
+  );
+
+  const fillColor = $derived(STATUS_COLORS[status] ?? STATUS_COLORS.unknown);
+</script>
+
+<div
+  class="bar-meter"
+  role="meter"
+  aria-label={label}
+  aria-valuenow={value ?? 0}
+  aria-valuemin={min}
+  aria-valuemax={max}
+>
+  {#each { length: blocks } as _, i}
+    {@const filled = i < filledCount}
+    <div
+      class="segment {filled ? 'segment--filled' : 'segment--empty'}"
+      style={filled ? `background: ${fillColor}; box-shadow: 0 0 3px ${fillColor};` : ''}
+    ></div>
+  {/each}
+</div>
+
+<style>
+  .bar-meter {
+    display: flex;
+    gap: 3px;
+    align-items: center;
+    width: 100%;
+  }
+
+  .segment {
+    flex: 1;
+    height: 10px;
+  }
+
+  .segment--empty {
+    background: var(--muted);
+    border: 1px solid var(--dimmer);
+  }
+
+  .segment--filled {
+    /* color applied via inline style */
+  }
+</style>

--- a/web/src/components/TemperatureGauge.svelte
+++ b/web/src/components/TemperatureGauge.svelte
@@ -1,0 +1,104 @@
+<script>
+  /**
+   * TemperatureGauge — vertical column of 16 discrete pixel blocks.
+   *
+   * Blocks fill from the bottom up as temperature increases.
+   * Each block is colored by its own temperature midpoint, so the column
+   * shows a visible blue→teal→green→amber→red gradient as the gauge fills.
+   *
+   * Props:
+   *   value   {number|null}  Current temperature in °C
+   *   min     {number}       Gauge minimum (default 0 °C)
+   *   max     {number}       Gauge maximum (default 40 °C)
+   *   blocks  {number}       Number of discrete steps (default 16)
+   */
+  let { value = null, min = 0, max = 40, blocks = 16 } = $props();
+
+  // Color stops keyed by the upper boundary of each temperature zone.
+  const COLOR_STOPS = [
+    { below: 10, color: '#0088ff' },  // blue   — cold
+    { below: 16, color: '#00ccbb' },  // teal   — cool
+    { below: 26, color: '#00ff41' },  // green  — comfortable
+    { below: 30, color: '#ffb000' },  // amber  — warm
+    { below: Infinity, color: '#ff3131' }, // red — hot
+  ];
+
+  function colorFor(tempC) {
+    for (const { below, color } of COLOR_STOPS) {
+      if (tempC < below) return color;
+    }
+    return '#ff3131';
+  }
+
+  /**
+   * Build the block array, bottom-first (index 0 = coldest block).
+   * CSS uses flex-direction: column-reverse to render bottom-first visually.
+   */
+  const blockData = $derived.by(() => {
+    const arr = [];
+    const range = max - min;
+    for (let i = 0; i < blocks; i++) {
+      const blockLo  = min + (i / blocks) * range;
+      const blockHi  = min + ((i + 1) / blocks) * range;
+      const blockMid = (blockLo + blockHi) / 2;
+      const filled   = value != null && value >= blockLo;
+      arr.push({ filled, color: colorFor(blockMid) });
+    }
+    return arr;
+  });
+
+  // Formatted temperature label
+  const label = $derived(value != null ? `${value.toFixed(1)}°` : '—°');
+</script>
+
+<div class="gauge" aria-label="Temperature gauge: {label}" role="img">
+  <div class="blocks">
+    {#each blockData as blk}
+      <div
+        class="block {blk.filled ? 'block--filled' : 'block--empty'}"
+        style={blk.filled ? `background:${blk.color}; box-shadow: 0 0 4px ${blk.color}88;` : ''}
+      ></div>
+    {/each}
+  </div>
+  <span class="gauge-label">{label}</span>
+</div>
+
+<style>
+  .gauge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--u2);
+    flex-shrink: 0;
+  }
+
+  .blocks {
+    display: flex;
+    flex-direction: column-reverse; /* index 0 renders at bottom */
+    gap: 3px;
+    width: 18px;
+  }
+
+  .block {
+    width: 18px;
+    height: 7px;
+    flex-shrink: 0;
+  }
+
+  .block--empty {
+    background: var(--muted);
+    border: 1px solid var(--dimmer);
+  }
+
+  .block--filled {
+    /* color and box-shadow set via inline style */
+  }
+
+  .gauge-label {
+    font-family: var(--font-pixel);
+    font-size: 6px;
+    color: var(--dim);
+    text-align: center;
+    line-height: 1;
+  }
+</style>

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8000',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
       '/ws': {
         target: 'ws://localhost:8000',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires the Climate and Air Quality panels to live API data. Introduces `TemperatureGauge`, `BarMeter`, and the polling loop.

### New components

**`TemperatureGauge`** — 16 discrete pixel blocks filling bottom-to-top. Each block is individually colored by its temperature midpoint: blue (<10 °C) → teal → green → amber → red (>30 °C), producing a visible gradient as the gauge fills.

**`BarMeter`** — horizontal row of discrete blocks, fill proportional to `(value − min) / (max − min)`. All filled blocks share the status color (`good` / `ok` / `warn` / `danger`) from the threshold table. Used for the CO₂ level bar (400–2000 ppm range) with scale labels below.

### Polling loop (`App.svelte`)

- `Promise.allSettled([fetchHealth, fetchSensors, fetchSensorStatus×3])` fired on mount and every 30 s.
- On error: `pollError = true`, retry delay doubles (cap 60 s); last known values held.
- On success: delay resets to 30 s, `lastPoll` timestamp updated.
- Cleans up `setTimeout` chain on component destroy.

### Panel content

**Climate (BME280):** `TemperatureGauge` left-column + three `ReadingRow`s (temperature, humidity, pressure) with LED indicators and status tinting.

**Air Quality (SCD40):** CO₂ `ReadingRow` + 12-block `BarMeter` with 400–2000 ppm scale + secondary temperature/humidity from the SCD40 when available.

**Audio:** carries forward PR 9 placeholder; live audio comes in PR 11.

### Also fixed

`vite.config.js` dev proxy now strips the `/api` prefix with a `rewrite` function before forwarding to the backend (which has bare `/sensors` etc. until PR 12 adds the `/api` prefix).

---

### Walkthrough

[arkadia_pr10_live_panels.mp4](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farkadia_pr10_live_panels.mp4)

[Full dashboard with live readings](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr10_dashboard.webp)

[Climate panel — temperature gauge + colored reading rows](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr10_climate.webp)

[Air quality panel — CO₂ bar meter](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr10_air.webp)

*(The "STALE" badges in the screenshots are expected — the test data was published with an old timestamp. On the Pi with live sensors, all badges will be absent.)*

---

**Testing**
- ✅ `npm run build` — zero warnings, 57 kB JS / 12 kB CSS
- ✅ Seeded MQTT with BME280 (22.4 °C, 51 %, 1013 hPa) and SCD40 (923 ppm CO₂) readings; dashboard populated correctly
- ✅ Temperature gauge fills to the correct block with correct gradient coloring
- ✅ CO₂ bar at 923 ppm fills into the amber/warn zone as expected
- ✅ LED indicators and value tinting match threshold rules
- ✅ Polling interval, error backoff, and last-poll timestamp all verified


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

