### PR TITLE
fix(scd40): stop periodic measurement before restarting; invalidate handle on timeout

### DIFF
--- a/services/scd40/sensor.py
+++ b/services/scd40/sensor.py
@@ -48,7 +48,15 @@ class SCD40Sensor(I2CBase):
         self._init_hardware()
 
     def _init_hardware(self) -> None:
-        """Open the I2C bus, initialise the SCD4X device, and start periodic measurement."""
+        """Open the I2C bus, initialise the SCD4X device, and start periodic measurement.
+
+        Always stops periodic measurement before starting it.  The SCD40 may
+        already be running from a previous process session (e.g. after a service
+        restart without a full power cycle).  Calling ``start_periodic_measurement``
+        on a sensor that is already measuring causes the command to be silently
+        rejected, leaving the sensor in an unexpected state.  Stopping first
+        guarantees a clean baseline regardless of prior state.
+        """
         try:
             import board  # type: ignore[import-untyped]
             import busio  # type: ignore[import-untyped]
@@ -56,6 +64,16 @@ class SCD40Sensor(I2CBase):
 
             self._i2c = busio.I2C(board.SCL, board.SDA)
             self._scd4x = adafruit_scd4x.SCD4X(self._i2c)
+
+            # Stop any in-progress measurement before starting fresh.
+            # The SCD40 datasheet requires a 500 ms idle period between
+            # stop and the next start command.
+            try:
+                self._scd4x.stop_periodic_measurement()
+                time.sleep(0.6)
+            except Exception:
+                pass  # sensor was idle — not an error
+
             self._scd4x.start_periodic_measurement()
             logger.info(
                 "SCD40 ready at I2C address 0x%02X (bus %d); periodic measurement started",
@@ -108,6 +126,10 @@ class SCD40Sensor(I2CBase):
             deadline = time.monotonic() + _DATA_READY_TIMEOUT
             while not self._scd4x.data_ready:
                 if time.monotonic() >= deadline:
+                    # Invalidate the device handle so the next read() call
+                    # fully reinitialises the sensor (stop → start) rather
+                    # than polling the same stuck device again.
+                    self._scd4x = None
                     raise I2CError(
                         f"SCD40 data_ready timeout after {_DATA_READY_TIMEOUT:.0f}s"
                     )

--- a/tests/test_scd40.py
+++ b/tests/test_scd40.py
@@ -179,9 +179,51 @@ class TestSCD40SensorRead:
         from sensor import SCD40Sensor
         s = SCD40Sensor()
         s.open()
+        stop_count_after_open = fake_device.stop_periodic_measurement.call_count
         s.close()
-        fake_device.stop_periodic_measurement.assert_called_once()
+        # close() must call stop_periodic_measurement exactly once more
+        assert fake_device.stop_periodic_measurement.call_count == stop_count_after_open + 1
         assert s._scd4x is None
+
+    def test_open_stops_before_starting_measurement(self):
+        """_init_hardware must stop periodic measurement before starting it."""
+        fake_device, _, _ = _inject_fakes()
+        from sensor import SCD40Sensor
+        s = SCD40Sensor()
+        s.open()
+        # stop must have been called before start
+        stop = fake_device.stop_periodic_measurement
+        start = fake_device.start_periodic_measurement
+        stop.assert_called()
+        start.assert_called_once()
+        # Verify ordering via call manager
+        manager = MagicMock()
+        manager.attach_mock(stop, 'stop')
+        manager.attach_mock(start, 'start')
+        # Both were called; stop appeared in call history first
+        call_names = [c[0] for c in fake_device.mock_calls]
+        stop_idx  = next(i for i, n in enumerate(call_names) if 'stop'  in n)
+        start_idx = next(i for i, n in enumerate(call_names) if 'start' in n)
+        assert stop_idx < start_idx, "stop_periodic_measurement must precede start_periodic_measurement"
+
+    def test_timeout_invalidates_device_handle(self):
+        """After a data_ready timeout, self._scd4x must be None so the next
+        read() call fully reinitialises the sensor."""
+        _inject_fakes(data_ready=False)
+        from sensor import SCD40Sensor
+        from common.i2c import I2CError
+        import sensor as sensor_mod
+        original = sensor_mod._DATA_READY_TIMEOUT
+        sensor_mod._DATA_READY_TIMEOUT = 0.2
+        try:
+            s = SCD40Sensor()
+            s.open()
+            assert s._scd4x is not None
+            with pytest.raises(I2CError, match="data_ready timeout"):
+                s.read()
+            assert s._scd4x is None, "device handle must be cleared after timeout"
+        finally:
+            sensor_mod._DATA_READY_TIMEOUT = original
 
     def test_data_ready_timeout_raises_i2c_error(self):
         """If data_ready never becomes True, read() raises I2CError."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

Two bugs combined to cause the persistent `data_ready timeout after 10s` loop seen in the logs.

### Bug 1 — `start_periodic_measurement` on an already-running sensor

`_init_hardware()` called `start_periodic_measurement()` without first calling `stop_periodic_measurement()`. The SCD40 datasheet specifies that `start_periodic_measurement` is only valid when the sensor is in idle mode — if it is already running (which it will be after any service restart without a power cycle), the command is **silently rejected**. The sensor stays in measurement mode but the internal measurement cycle gets confused, causing `data_ready` to never assert.

**Fix:** Always call `stop_periodic_measurement()` + 600 ms sleep (datasheet minimum: 500 ms) before `start_periodic_measurement()` in `_init_hardware()`.

### Bug 2 — Stuck device handle after a timeout

When `data_ready` timed out in `read()`, `self._scd4x` was left pointing at the same stuck device object. Every subsequent sample in the current cycle called `read()` again, polled the same unresponsive device, and timed out again — producing the chain of three `Sample 1/3 failed … Sample 2/3 failed … Sample 3/3 failed` entries seen in the logs.

**Fix:** Set `self._scd4x = None` before raising `I2CError` on timeout. The next `read()` call detects `None`, calls `_init_hardware()`, which now performs the full stop → idle → start reset.

## Effect on the observed log pattern

Before this fix, the cycle was:
1. `_init_hardware` → `start` (no-op, sensor already running) → `data_ready` never fires → 10 s timeout
2. Samples 2 and 3 repeat on the same stuck handle → two more 10 s timeouts
3. All samples failed, cycle skipped, sleep 60 s
4. Repeat forever

After this fix:
1. `_init_hardware` → `stop` + 600 ms → `start` (fresh measurement cycle)
2. `data_ready` fires within 5 s → read succeeds
3. If a timeout does occur, `self._scd4x = None` → next sample reinitialises the sensor

## Deployment

```bash
sudo bash scripts/deploy.sh
```

No configuration or virtualenv changes needed.

## Tests

- ✅ `test_open_stops_before_starting_measurement` — verifies `stop` precedes `start` in call order
- ✅ `test_timeout_invalidates_device_handle` — verifies `self._scd4x is None` after timeout
- ✅ `test_close_stops_measurement` — updated to count stop calls correctly
- ✅ All 263 tests pass, ruff clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

