### PR TITLE
feat(web): implement real-time audio panel with EQ and waveform (PR 11)

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -343,10 +343,10 @@
         </div>
 
         <!-- Real-time EQ visualizer -->
-        <EQVisualizer {getAudioFrame} connected={wsConnected} />
+        <EQVisualizer getFrame={getAudioFrame} connected={wsConnected} />
 
         <!-- Real-time waveform oscilloscope -->
-        <WaveformScope {getAudioFrame} connected={wsConnected} />
+        <WaveformScope getFrame={getAudioFrame} connected={wsConnected} />
 
         <!-- Summary RMS level from polled /sensors/inmp441 -->
         {#if inmp441.readings}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -8,6 +8,7 @@
     fetchHealth,
     fetchSensors,
     fetchSensorStatus,
+    createAudioStream,
     formatRelativeTime,
     formatHMS,
   } from './api.js';
@@ -16,9 +17,11 @@
   import SensorCard    from './components/SensorCard.svelte';
   import StatusBar     from './components/StatusBar.svelte';
   import SettingsModal from './components/SettingsModal.svelte';
-  import ReadingRow    from './components/ReadingRow.svelte';
+  import ReadingRow       from './components/ReadingRow.svelte';
   import TemperatureGauge from './components/TemperatureGauge.svelte';
-  import BarMeter      from './components/BarMeter.svelte';
+  import BarMeter         from './components/BarMeter.svelte';
+  import EQVisualizer     from './components/EQVisualizer.svelte';
+  import WaveformScope    from './components/WaveformScope.svelte';
 
   // ---------------------------------------------------------------------------
   // Settings gate
@@ -110,6 +113,19 @@
   const scdHumStatus  = $derived(statusFor(scdHumPct, THRESHOLDS.humidity_pct));
 
   // ---------------------------------------------------------------------------
+  // WebSocket audio stream
+  // ---------------------------------------------------------------------------
+
+  // Plain mutable variable — not $state — to avoid deep-tracking a large
+  // object (waveform has 2400 samples) at 20 Hz.
+  let latestAudioFrame = null;
+  let wsConnected      = $state(false);
+
+  // Getter function passed to canvas components so they always read the
+  // current frame from inside their rAF loops without needing reactivity.
+  function getAudioFrame() { return latestAudioFrame; }
+
+  // ---------------------------------------------------------------------------
   // Polling
   // ---------------------------------------------------------------------------
   let brokerConnected = $state(false);
@@ -175,12 +191,23 @@
   // ---------------------------------------------------------------------------
   onMount(() => {
     if (apiKey) startBoot();
-    // Start polling after the boot animation, or immediately if already loaded.
+
+    // Start polling after boot animation
     const delay = apiKey ? 1800 : 0;
     pollTimer = setTimeout(schedulePoll, delay);
 
+    // Open WebSocket audio stream immediately (it reconnects automatically)
+    let audioStream = null;
+    if (apiKey) {
+      audioStream = createAudioStream(
+        (frame) => { latestAudioFrame = frame; },
+        (status) => { wsConnected = status === 'connected'; },
+      );
+    }
+
     return () => {
       if (pollTimer) clearTimeout(pollTimer);
+      audioStream?.close();
     };
   });
 </script>
@@ -301,7 +328,7 @@
         {/if}
       </SensorCard>
 
-      <!-- ── AUDIO (INMP441) — placeholder until PR 11 ─────────────── -->
+      <!-- ── AUDIO (INMP441) ────────────────────────────────────────── -->
       <SensorCard
         title={inmp441.title}
         sensorId="inmp441"
@@ -309,51 +336,31 @@
         lastSeen={inmp441.lastSeen}
         stale={inmp441.stale}
       >
-        <!-- EQ bar placeholder with colored tops -->
-        <div class="eq-placeholder" aria-label="Equalizer placeholder">
-          {#each [
-            { h: 6,  top: 'ok'     },
-            { h: 10, top: 'good'   },
-            { h: 8,  top: 'ok'     },
-            { h: 14, top: 'warn'   },
-            { h: 12, top: 'warn'   },
-            { h: 9,  top: 'ok'     },
-            { h: 5,  top: 'good'   },
-            { h: 7,  top: 'ok'     },
-          ] as bar}
-            <div class="eq-col" style="height: {bar.h * 6}px">
-              <div class="eq-top eq-top--{bar.top}"></div>
-            </div>
-          {/each}
+        <!-- WebSocket status badge -->
+        <div class="ws-status">
+          <span class="dot {wsConnected ? 'dot--online' : 'dot--unknown'}">●</span>
+          <span class="label">{wsConnected ? 'STREAM LIVE' : 'STREAM IDLE'}</span>
         </div>
 
-        <!-- Waveform oscilloscope placeholder -->
-        <div class="waveform-placeholder">
-          <span class="label">WAVEFORM</span>
-          <div class="waveform-screen">
-            <svg width="100%" height="48" preserveAspectRatio="none" aria-hidden="true">
-              <polyline
-                points="0,24 20,24 40,23 60,25 80,24 100,24 120,23 140,25 160,24 180,24 200,23 220,25 240,24 260,24 280,23 300,25 320,24"
-                fill="none" stroke="var(--dimmer)" stroke-width="1.5"
-              />
-            </svg>
-          </div>
-        </div>
+        <!-- Real-time EQ visualizer -->
+        <EQVisualizer {getAudioFrame} connected={wsConnected} />
 
+        <!-- Real-time waveform oscilloscope -->
+        <WaveformScope {getAudioFrame} connected={wsConnected} />
+
+        <!-- Summary RMS level from polled /sensors/inmp441 -->
         {#if inmp441.readings}
           {@const dbfs = inmp441.readings.db_level}
           <ReadingRow
-            label="LEVEL"
+            label="RMS (5s AVG)"
             value={dbfs.toFixed(1)}
             unit=" dBFS"
             status={statusFor(dbfs, THRESHOLDS.db_level)}
             sub={`~${dbfsToDB(dbfs).toFixed(1)} dB SPL`}
           />
         {:else}
-          <ReadingRow label="LEVEL" value="——" unit=" dBFS" status="unknown" sub="~—— dB SPL" />
+          <ReadingRow label="RMS (5s AVG)" value="——" unit=" dBFS" status="unknown" sub="~—— dB SPL" />
         {/if}
-
-        <p class="coming-soon muted">LIVE AUDIO IN PR 11</p>
       </SensorCard>
     </main>
 
@@ -430,30 +437,12 @@
     padding-top: var(--u2);
   }
 
-  /* Audio panel EQ placeholder */
-  .eq-placeholder {
-    display: flex; align-items: flex-end; gap: 4px;
-    height: 90px; border-bottom: 1px solid var(--dimmer); margin-bottom: var(--u2);
-  }
-  .eq-col {
-    flex: 1; min-width: 8px; background: var(--dim);
-    position: relative; display: flex; flex-direction: column; justify-content: flex-start;
-  }
-  .eq-top { height: 4px; width: 100%; flex-shrink: 0; }
-  .eq-top--good   { background: var(--status-good);   box-shadow: 0 0 4px var(--status-good);   }
-  .eq-top--ok     { background: var(--status-ok);     box-shadow: 0 0 4px var(--status-ok);     }
-  .eq-top--warn   { background: var(--status-warn);   box-shadow: 0 0 4px var(--status-warn);   }
-  .eq-top--danger { background: var(--status-danger); box-shadow: 0 0 4px var(--status-danger); }
-
-  /* Waveform placeholder */
-  .waveform-placeholder { display: flex; flex-direction: column; gap: var(--u2); }
-  .waveform-screen {
-    background: var(--bg); border: 1px solid var(--dimmer); padding: var(--u2);
-    box-shadow: inset 0 0 8px rgba(0,255,65,0.04);
-  }
-
-  .coming-soon {
-    font-family: var(--font-pixel); font-size: 7px;
-    margin-top: var(--u2); padding-top: var(--u3); border-top: 1px solid var(--dimmer);
+  /* WebSocket stream status */
+  .ws-status {
+    display: flex;
+    align-items: center;
+    gap: var(--u2);
+    padding-bottom: var(--u3);
+    border-bottom: 1px solid var(--dimmer);
   }
 </style>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -342,8 +342,10 @@
           <span class="label">{wsConnected ? 'STREAM LIVE' : 'STREAM IDLE'}</span>
         </div>
 
-        <!-- Real-time EQ visualizer -->
-        <EQVisualizer getFrame={getAudioFrame} connected={wsConnected} />
+        <!-- Real-time EQ visualizer.
+             Tune `gain` here: 30 dB lifts typical room audio (-60 to -50 dBFS)
+             into the 50-75% bar range. Raise if bars look flat; lower if clipping. -->
+        <EQVisualizer getFrame={getAudioFrame} connected={wsConnected} gain={30} />
 
         <!-- Real-time waveform oscilloscope.
              Tune `gain` here: 8 = good for typical room audio (-30 to -40 dBFS).

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -348,7 +348,7 @@
         <!-- Real-time waveform oscilloscope.
              Tune `gain` here: 8 = good for typical room audio (-30 to -40 dBFS).
              Increase if the signal still looks flat; decrease if it clips. -->
-        <WaveformScope getFrame={getAudioFrame} connected={wsConnected} gain={8} />
+        <WaveformScope getFrame={getAudioFrame} connected={wsConnected} gain={24} />
 
         <!-- Summary RMS level from polled /sensors/inmp441 -->
         {#if inmp441.readings}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -345,8 +345,10 @@
         <!-- Real-time EQ visualizer -->
         <EQVisualizer getFrame={getAudioFrame} connected={wsConnected} />
 
-        <!-- Real-time waveform oscilloscope -->
-        <WaveformScope getFrame={getAudioFrame} connected={wsConnected} />
+        <!-- Real-time waveform oscilloscope.
+             Tune `gain` here: 8 = good for typical room audio (-30 to -40 dBFS).
+             Increase if the signal still looks flat; decrease if it clips. -->
+        <WaveformScope getFrame={getAudioFrame} connected={wsConnected} gain={8} />
 
         <!-- Summary RMS level from polled /sensors/inmp441 -->
         {#if inmp441.readings}

--- a/web/src/components/EQVisualizer.svelte
+++ b/web/src/components/EQVisualizer.svelte
@@ -1,0 +1,206 @@
+<script>
+  /**
+   * EQVisualizer — 8-band retro equalizer drawn on a <canvas>.
+   *
+   * Each of the 8 ISO 266 octave bands is drawn as a column of discrete
+   * pixel blocks.  The top block of each column is color-coded by amplitude
+   * (green → lime → amber → red).  A peak-hold dot sits above the column and
+   * decays at 18 dB/s after a 0.6 s hold period.
+   *
+   * When disconnected, bars pulse slowly with a sine wave idle animation.
+   *
+   * Props:
+   *   getFrame   {() => object|null}  Function returning latest AudioStreamPayload
+   *   connected  {boolean}            Whether the WebSocket is connected
+   */
+  import { onMount } from 'svelte';
+
+  let { getFrame = () => null, connected = false } = $props();
+
+  let container = $state(null);
+  let canvas    = $state(null);
+
+  // -- Constants -------------------------------------------------------------
+  const BANDS       = 8;
+  const BLOCKS      = 20;       // discrete height steps per bar
+  const FLOOR_DB    = -80;      // level that maps to 0 blocks
+  const GAP_PX      = 5;        // pixels between bars
+  const PEAK_HOLD   = 0.6;      // seconds before decay starts
+  const DECAY_RATE  = 18;       // dB per second decay
+
+  const COLOR_BODY   = '#005c17';  // filled block body (--dimmer approx)
+  const COLOR_EMPTY  = '#1e3a1e';  // empty block (--muted approx)
+  const COLOR_STATUS = {
+    good:    '#00ff41',
+    ok:      '#aaff00',
+    warn:    '#ffb000',
+    danger:  '#ff3131',
+    idle:    '#003a0e',
+  };
+
+  function levelToStatus(db) {
+    if (db < -30) return 'good';
+    if (db < -15) return 'ok';
+    if (db < -6)  return 'warn';
+    return 'danger';
+  }
+
+  function levelToBlocks(db) {
+    const ratio = Math.max(0, Math.min(1, (db - FLOOR_DB) / -FLOOR_DB));
+    return Math.round(ratio * BLOCKS);
+  }
+
+  // -- Animation state (plain vars, not reactive) ----------------------------
+  let peaks      = Array.from({ length: BANDS }, () => FLOOR_DB);
+  let holdTimers = Array.from({ length: BANDS }, () => 0); // seconds since last peak update
+  let animId     = null;
+  let lastTime   = null;
+
+  // -- Canvas drawing --------------------------------------------------------
+
+  function drawFrame(ctx, w, h, frame, t, dt) {
+    ctx.clearRect(0, 0, w, h);
+
+    const blockH = Math.floor(h / BLOCKS);
+    const totalGap = GAP_PX * (BANDS - 1);
+    const barW = Math.max(4, Math.floor((w - totalGap) / BANDS));
+
+    for (let i = 0; i < BANDS; i++) {
+      const x = i * (barW + GAP_PX);
+
+      let blocks, topStatus;
+
+      if (connected && frame?.readings?.eq_bands?.levels_db) {
+        const db = frame.readings.eq_bands.levels_db[i] ?? FLOOR_DB;
+        blocks    = levelToBlocks(db);
+        topStatus = levelToStatus(db);
+
+        // Peak hold
+        if (db > peaks[i]) {
+          peaks[i]      = db;
+          holdTimers[i] = 0;
+        }
+      } else {
+        // Idle: gentle sine-wave pulse, offset per band
+        const phase = (i / BANDS) * Math.PI * 2;
+        const idleRatio = 0.08 + 0.04 * Math.sin(2 * Math.PI * 0.4 * t + phase);
+        blocks    = Math.round(idleRatio * BLOCKS);
+        topStatus = 'idle';
+        peaks[i]  = FLOOR_DB; // reset peaks when disconnected
+      }
+
+      // -- Decay peaks -------------------------------------------------------
+      holdTimers[i] += dt;
+      if (holdTimers[i] > PEAK_HOLD) {
+        peaks[i] -= DECAY_RATE * dt;
+        peaks[i]  = Math.max(peaks[i], FLOOR_DB);
+      }
+
+      // -- Draw empty blocks -------------------------------------------------
+      ctx.fillStyle = COLOR_EMPTY;
+      for (let b = blocks; b < BLOCKS; b++) {
+        const by = h - (b + 1) * blockH;
+        ctx.fillRect(x, by + 1, barW, blockH - 2);
+      }
+
+      // -- Draw filled blocks (body, excluding the top cap) ------------------
+      if (blocks > 1) {
+        ctx.fillStyle = COLOR_BODY;
+        ctx.fillRect(x, h - (blocks - 1) * blockH, barW, (blocks - 1) * blockH - 1);
+      }
+
+      // -- Draw top cap (colored by amplitude) -------------------------------
+      if (blocks > 0) {
+        const capColor = COLOR_STATUS[topStatus];
+        ctx.fillStyle = capColor;
+        ctx.shadowColor = capColor;
+        ctx.shadowBlur  = topStatus !== 'idle' ? 6 : 0;
+        ctx.fillRect(x, h - blocks * blockH, barW, blockH - 1);
+        ctx.shadowBlur = 0;
+      }
+
+      // -- Draw peak-hold dot ------------------------------------------------
+      if (connected && peaks[i] > FLOOR_DB + 1) {
+        const peakBlocks = levelToBlocks(peaks[i]);
+        if (peakBlocks > blocks) {
+          const peakColor = COLOR_STATUS[levelToStatus(peaks[i])];
+          ctx.fillStyle   = peakColor;
+          ctx.shadowColor = peakColor;
+          ctx.shadowBlur  = 8;
+          const dotY = h - peakBlocks * blockH - 3;
+          ctx.fillRect(x, dotY, barW, 2);
+          ctx.shadowBlur = 0;
+        }
+      }
+    }
+
+    // -- Band labels ---------------------------------------------------------
+    const LABELS = ['63', '125', '250', '500', '1k', '2k', '4k', '8k'];
+    ctx.fillStyle = '#005c17';
+    ctx.font = '7px monospace';
+    ctx.textAlign = 'center';
+    for (let i = 0; i < BANDS; i++) {
+      const x = i * (barW + GAP_PX) + barW / 2;
+      ctx.fillText(LABELS[i], x, h - 1);
+    }
+  }
+
+  // -- rAF loop --------------------------------------------------------------
+
+  $effect(() => {
+    if (!canvas || !container) return;
+
+    // Resize canvas to match container
+    const ro = new ResizeObserver(([entry]) => {
+      canvas.width  = Math.floor(entry.contentRect.width);
+      canvas.height = 120;
+    });
+    ro.observe(container);
+
+    // Animation loop
+    let running = true;
+
+    function loop(ts) {
+      if (!running) return;
+
+      const t  = ts / 1000;
+      const dt = lastTime != null ? Math.min((ts - lastTime) / 1000, 0.1) : 0;
+      lastTime = ts;
+
+      const frame = getFrame();
+      const ctx   = canvas.getContext('2d');
+      if (ctx) drawFrame(ctx, canvas.width, canvas.height, frame, t, dt);
+
+      animId = requestAnimationFrame(loop);
+    }
+
+    animId = requestAnimationFrame(loop);
+
+    return () => {
+      running = false;
+      cancelAnimationFrame(animId);
+      ro.disconnect();
+    };
+  });
+</script>
+
+<div bind:this={container} class="eq-container" aria-label="Equalizer visualization">
+  <canvas bind:this={canvas} class="eq-canvas"></canvas>
+</div>
+
+<style>
+  .eq-container {
+    width: 100%;
+    position: relative;
+    border-bottom: 1px solid var(--dimmer);
+    padding-bottom: var(--u2);
+    margin-bottom: var(--u2);
+  }
+
+  .eq-canvas {
+    display: block;
+    width: 100%;
+    height: 120px;
+    image-rendering: pixelated;
+  }
+</style>

--- a/web/src/components/EQVisualizer.svelte
+++ b/web/src/components/EQVisualizer.svelte
@@ -12,10 +12,17 @@
    * Props:
    *   getFrame   {() => object|null}  Function returning latest AudioStreamPayload
    *   connected  {boolean}            Whether the WebSocket is connected
+   *   gain       {number}             dB boost added to each band before height
+   *                                   mapping (default 30).  Does NOT affect the
+   *                                   color thresholds, which stay anchored to
+   *                                   actual amplitude.  Typical EQ bands for
+   *                                   quiet room audio sit around -60 to -50 dBFS;
+   *                                   gain=30 lifts those into the 50–75 % range.
+   *                                   Raise if bars look flat; lower if they clip.
    */
   import { onMount } from 'svelte';
 
-  let { getFrame = () => null, connected = false } = $props();
+  let { getFrame = () => null, connected = false, gain = 30 } = $props();
 
   let container = $state(null);
   let canvas    = $state(null);
@@ -46,7 +53,10 @@
   }
 
   function levelToBlocks(db) {
-    const ratio = Math.max(0, Math.min(1, (db - FLOOR_DB) / -FLOOR_DB));
+    // Apply gain (dB boost) for display height only.
+    // Clamp so a very high gain never pushes past the top block.
+    const boosted = Math.min(0, db + gain);
+    const ratio   = Math.max(0, Math.min(1, (boosted - FLOOR_DB) / -FLOOR_DB));
     return Math.round(ratio * BLOCKS);
   }
 

--- a/web/src/components/EQVisualizer.svelte
+++ b/web/src/components/EQVisualizer.svelte
@@ -83,7 +83,7 @@
       if (connected && frame?.readings?.eq_bands?.levels_db) {
         const db = frame.readings.eq_bands.levels_db[i] ?? FLOOR_DB;
         blocks    = levelToBlocks(db);
-        topStatus = levelToStatus(db);
+        topStatus = levelToStatus(db + gain);  // color matches visual bar height
 
         // Peak hold
         if (db > peaks[i]) {
@@ -133,7 +133,7 @@
       if (connected && peaks[i] > FLOOR_DB + 1) {
         const peakBlocks = levelToBlocks(peaks[i]);
         if (peakBlocks > blocks) {
-          const peakColor = COLOR_STATUS[levelToStatus(peaks[i])];
+          const peakColor = COLOR_STATUS[levelToStatus(peaks[i] + gain)];
           ctx.fillStyle   = peakColor;
           ctx.shadowColor = peakColor;
           ctx.shadowBlur  = 8;

--- a/web/src/components/WaveformScope.svelte
+++ b/web/src/components/WaveformScope.svelte
@@ -1,0 +1,164 @@
+<script>
+  /**
+   * WaveformScope — oscilloscope-style waveform drawn on a <canvas>.
+   *
+   * The waveform array from the AudioStreamPayload is downsampled to fit the
+   * canvas width.  Y positions are snapped to a 2-pixel grid to give a
+   * chunky, retro oscilloscope feel.  A phosphor glow is applied via
+   * ctx.shadowBlur.
+   *
+   * When disconnected, a flat idle line is shown with a slow pulse.
+   *
+   * Props:
+   *   getFrame   {() => object|null}  Function returning latest AudioStreamPayload
+   *   connected  {boolean}            Whether the WebSocket is connected
+   */
+  import { onMount } from 'svelte';
+
+  let { getFrame = () => null, connected = false } = $props();
+
+  let container = $state(null);
+  let canvas    = $state(null);
+
+  const HEIGHT_PX  = 72;
+  const GRID_SNAP  = 2;    // snap y to this many pixels for pixelated look
+  const GLOW_COLOR = '#00ff41';
+  const IDLE_COLOR = '#003a0e';
+
+  function snapY(y) {
+    return Math.round(y / GRID_SNAP) * GRID_SNAP;
+  }
+
+  function drawFrame(ctx, w, h, frame, t) {
+    ctx.clearRect(0, 0, w, h);
+
+    const midY = h / 2;
+
+    if (connected && frame?.readings?.waveform?.length > 0) {
+      const samples = frame.readings.waveform;
+      const stride  = Math.max(1, Math.floor(samples.length / w));
+
+      // Draw with phosphor glow
+      ctx.strokeStyle = GLOW_COLOR;
+      ctx.shadowColor = GLOW_COLOR;
+      ctx.shadowBlur  = 5;
+      ctx.lineWidth   = 1.5;
+      ctx.beginPath();
+
+      for (let px = 0; px < w; px++) {
+        const si  = Math.min(Math.floor(px * samples.length / w), samples.length - 1);
+        const amp = samples[si]; // [-1, 1]
+        const y   = snapY(midY - amp * (midY - 4));
+
+        if (px === 0) ctx.moveTo(px, y);
+        else          ctx.lineTo(px, y);
+      }
+
+      ctx.stroke();
+      ctx.shadowBlur = 0;
+
+      // Second pass: crisp bright line on top of glow
+      ctx.strokeStyle = '#39ff14';
+      ctx.shadowBlur  = 0;
+      ctx.lineWidth   = 1;
+      ctx.beginPath();
+
+      for (let px = 0; px < w; px++) {
+        const si  = Math.min(Math.floor(px * samples.length / w), samples.length - 1);
+        const amp = samples[si];
+        const y   = snapY(midY - amp * (midY - 4));
+
+        if (px === 0) ctx.moveTo(px, y);
+        else          ctx.lineTo(px, y);
+      }
+      ctx.stroke();
+
+    } else {
+      // Idle: slow flat line with faint pulse
+      const pulse = 0.3 + 0.15 * Math.sin(2 * Math.PI * 0.6 * t);
+      ctx.strokeStyle = IDLE_COLOR;
+      ctx.globalAlpha = pulse;
+      ctx.lineWidth   = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(0, snapY(midY));
+      ctx.lineTo(w, snapY(midY));
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+    }
+
+    // Centre graticule line (very faint)
+    ctx.strokeStyle = '#0a1a0a';
+    ctx.lineWidth   = 1;
+    ctx.setLineDash([4, 8]);
+    ctx.beginPath();
+    ctx.moveTo(0, midY);
+    ctx.lineTo(w, midY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  let animId   = null;
+  let lastTime = null;
+
+  $effect(() => {
+    if (!canvas || !container) return;
+
+    const ro = new ResizeObserver(([entry]) => {
+      // Half-resolution canvas for chunky pixel look, stretched by CSS
+      canvas.width  = Math.floor(entry.contentRect.width / 2);
+      canvas.height = HEIGHT_PX / 2;
+    });
+    ro.observe(container);
+
+    let running = true;
+
+    function loop(ts) {
+      if (!running) return;
+      const t = ts / 1000;
+
+      const frame = getFrame();
+      const ctx   = canvas.getContext('2d');
+      if (ctx) drawFrame(ctx, canvas.width, canvas.height, frame, t);
+
+      animId = requestAnimationFrame(loop);
+    }
+
+    animId = requestAnimationFrame(loop);
+
+    return () => {
+      running = false;
+      cancelAnimationFrame(animId);
+      ro.disconnect();
+    };
+  });
+</script>
+
+<div bind:this={container} class="scope-container" aria-label="Waveform oscilloscope">
+  <div class="scope-label label">WAVEFORM</div>
+  <div class="scope-screen">
+    <canvas bind:this={canvas} class="scope-canvas"></canvas>
+  </div>
+</div>
+
+<style>
+  .scope-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u2);
+  }
+
+  .scope-screen {
+    background: var(--bg);
+    border: 1px solid var(--dimmer);
+    padding: 2px;
+    box-shadow: inset 0 0 10px rgba(0, 255, 65, 0.05);
+    overflow: hidden;
+  }
+
+  .scope-canvas {
+    display: block;
+    width: 100%;
+    height: 72px;
+    image-rendering: pixelated;
+  }
+</style>

--- a/web/src/components/WaveformScope.svelte
+++ b/web/src/components/WaveformScope.svelte
@@ -3,25 +3,30 @@
    * WaveformScope — oscilloscope-style waveform drawn on a <canvas>.
    *
    * The waveform array from the AudioStreamPayload is downsampled to fit the
-   * canvas width.  Y positions are snapped to a 2-pixel grid to give a
-   * chunky, retro oscilloscope feel.  A phosphor glow is applied via
-   * ctx.shadowBlur.
+   * canvas width.  Y positions are snapped to a pixel grid to give a chunky,
+   * retro oscilloscope feel.  A phosphor glow is applied via ctx.shadowBlur.
    *
    * When disconnected, a flat idle line is shown with a slow pulse.
    *
    * Props:
    *   getFrame   {() => object|null}  Function returning latest AudioStreamPayload
    *   connected  {boolean}            Whether the WebSocket is connected
+   *   gain       {number}             Y-axis amplification (default 8).
+   *                                   Typical room audio sits at -30 to -40 dBFS
+   *                                   (amplitude ≈ 0.01–0.03); gain=8 maps those
+   *                                   signals to a clearly visible deflection.
+   *                                   Values are clamped after amplification so
+   *                                   loud signals never clip visually.
    */
   import { onMount } from 'svelte';
 
-  let { getFrame = () => null, connected = false } = $props();
+  let { getFrame = () => null, connected = false, gain = 8 } = $props();
 
   let container = $state(null);
   let canvas    = $state(null);
 
   const HEIGHT_PX  = 72;
-  const GRID_SNAP  = 2;    // snap y to this many pixels for pixelated look
+  const GRID_SNAP  = 1;    // 1px snap — gain already provides the retro stepped look
   const GLOW_COLOR = '#00ff41';
   const IDLE_COLOR = '#003a0e';
 
@@ -32,11 +37,18 @@
   function drawFrame(ctx, w, h, frame, t) {
     ctx.clearRect(0, 0, w, h);
 
-    const midY = h / 2;
+    const midY      = h / 2;
+    const maxDefl   = midY - 2;   // leave 2px margin top and bottom
 
     if (connected && frame?.readings?.waveform?.length > 0) {
       const samples = frame.readings.waveform;
-      const stride  = Math.max(1, Math.floor(samples.length / w));
+
+      // Helper: amplify, clamp, then snap to grid
+      function sampleY(si) {
+        const raw     = samples[Math.min(si, samples.length - 1)];
+        const amp     = Math.max(-1, Math.min(1, raw * gain));
+        return snapY(midY - amp * maxDefl);
+      }
 
       // Draw with phosphor glow
       ctx.strokeStyle = GLOW_COLOR;
@@ -46,10 +58,8 @@
       ctx.beginPath();
 
       for (let px = 0; px < w; px++) {
-        const si  = Math.min(Math.floor(px * samples.length / w), samples.length - 1);
-        const amp = samples[si]; // [-1, 1]
-        const y   = snapY(midY - amp * (midY - 4));
-
+        const si = Math.floor(px * samples.length / w);
+        const y  = sampleY(si);
         if (px === 0) ctx.moveTo(px, y);
         else          ctx.lineTo(px, y);
       }
@@ -59,15 +69,12 @@
 
       // Second pass: crisp bright line on top of glow
       ctx.strokeStyle = '#39ff14';
-      ctx.shadowBlur  = 0;
       ctx.lineWidth   = 1;
       ctx.beginPath();
 
       for (let px = 0; px < w; px++) {
-        const si  = Math.min(Math.floor(px * samples.length / w), samples.length - 1);
-        const amp = samples[si];
-        const y   = snapY(midY - amp * (midY - 4));
-
+        const si = Math.floor(px * samples.length / w);
+        const y  = sampleY(si);
         if (px === 0) ctx.moveTo(px, y);
         else          ctx.lineTo(px, y);
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the real-time audio panel with canvas-based EQ visualizer and waveform oscilloscope, completing the core visualization work planned for PR 11.

---

### `EQVisualizer.svelte`

- `<canvas>` driven by a `requestAnimationFrame` loop set up in a Svelte 5 `$effect`
- 8 ISO 266 octave-band columns × 20 discrete pixel blocks each (floor = −80 dBFS)
- **Amplitude coloring** on the top block of each bar: `good` (<−30 dBFS, green) → `ok` (<−15, lime) → `warn` (<−6, amber) → `danger` (≥−6, red), with a matching glow
- **Peak-hold dot**: appears above the active bar, holds for 0.6 s, then decays at 18 dB/s
- **Idle animation**: bars pulse gently on a per-band sine offset while the WebSocket is disconnected
- Band-frequency labels drawn at canvas bottom (63 / 125 / 250 / 500 / 1k / 2k / 4k / 8k)
- `ResizeObserver` keeps `canvas.width` matched to the container on every layout change

### `WaveformScope.svelte`

- `<canvas>` at half the CSS pixel width, stretched with `image-rendering: pixelated` — produces a chunky retro oscilloscope look at no extra cost
- **Live**: downsamples the 2400-sample waveform to canvas width, snaps y-positions to a 2 px grid; double-pass render (first `shadowBlur=5` glow pass, then a crisp bright overline)
- **Idle**: slowly pulsing flat line + faint dashed centre graticule

### `App.svelte` changes

- `latestAudioFrame` is a plain `let` (not `$state`) to avoid Svelte deep-tracking a 2400-sample array at 20 Hz; a `getAudioFrame()` getter is passed to canvas components so their rAF loops always read the current value
- `wsConnected` is `$state` — only changes on connect/disconnect, so negligible overhead
- `createAudioStream()` called on mount, closed on component destroy
- Audio panel now shows: WebSocket status badge → `EQVisualizer` → `WaveformScope` → `ReadingRow` for 5 s-average RMS in dBFS + ~dB SPL (from polled `/sensors/inmp441`)

---

### Walkthrough

[arkadia_pr11_audio_panel.mp4](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farkadia_pr11_audio_panel.mp4)

[Full dashboard with audio panel](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr11_dashboard.webp)

[Audio panel close-up — idle EQ animation and waveform scope](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr11_audio_idle.webp)

[Audio panel 3 seconds later — idle animation confirmed running](https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr11_audio_animated.webp)

---

**Testing**
- ✅ `npm run build` — zero warnings, 62 kB JS / 12 kB CSS
- ✅ EQ idle animation verified running across two screenshots 3 s apart
- ✅ Waveform scope shows flat idle line with pulsing glow
- ✅ WebSocket status badge shows "STREAM IDLE" when no audio service is connected
- ✅ RMS row shows placeholder until `inmp441` sensor data arrives
- ✅ No layout breakage on Climate or Air Quality panels


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

