### PR TITLE
feat(sgp40): add SGP40 VOC sensor service and dashboard indicator

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -95,6 +95,19 @@ class SCD40Readings(BaseModel):
     humidity_pct: float | None = Field(None, ge=0, le=100, description="Relative humidity in percent (if available)")
 
 
+class SGP40Readings(BaseModel):
+    """VOC Index from the SGP40 gas sensor.
+
+    The VOC Index is a processed integer on the Sensirion scale (1–500).
+    100 represents typical indoor air; values below 100 indicate cleaner-
+    than-average air, values above 100 indicate increasing VOC contamination.
+    """
+
+    voc_index: int = Field(
+        ..., ge=0, le=500, description="VOC Index (Sensirion scale 1–500; 100 = average indoor air)"
+    )
+
+
 class AudioReadings(BaseModel):
     """Ambient sound level from the INMP441 microphone.
 
@@ -202,7 +215,7 @@ class SensorPayload(_UTCTimestampMixin):
     schema_version: Literal[1] = 1
     sensor_id: str = Field(..., min_length=1)
     timestamp: datetime = Field(..., description="UTC ISO 8601 timestamp of the reading")
-    readings: BME280Readings | SCD40Readings | AudioReadings | AudioStreamReadings
+    readings: BME280Readings | SCD40Readings | SGP40Readings | AudioReadings | AudioStreamReadings
     meta: Meta | StreamMeta
     diagnostics: Diagnostics | None = None
 
@@ -230,6 +243,17 @@ class SCD40Payload(_UTCTimestampMixin):
     sensor_id: str = Field("scd40", pattern=r"^scd40$")
     timestamp: datetime
     readings: SCD40Readings
+    meta: Meta
+    diagnostics: Diagnostics | None = None
+
+
+class SGP40Payload(_UTCTimestampMixin):
+    """Fully-typed payload for the SGP40 VOC sensor."""
+
+    schema_version: Literal[1] = 1
+    sensor_id: str = Field("sgp40", pattern=r"^sgp40$")
+    timestamp: datetime
+    readings: SGP40Readings
     meta: Meta
     diagnostics: Diagnostics | None = None
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,8 +17,8 @@ ENV_FILE="/etc/home-monitor.env"
 
 # Ordered service list: mosquitto is a system service installed separately;
 # sensor services and api are the Arkadia-managed units.
-SENSOR_SERVICES=(bme280 scd40 audio)
-ALL_ARKADIA_SERVICES=(bme280 scd40 audio api)
+SENSOR_SERVICES=(bme280 scd40 sgp40 audio)
+ALL_ARKADIA_SERVICES=(bme280 scd40 sgp40 audio api)
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -203,7 +203,7 @@ EOF
 # 5. Per-service Python virtualenvs
 # ---------------------------------------------------------------------------
 
-SERVICES=(bme280 scd40 audio api)
+SERVICES=(bme280 scd40 sgp40 audio api)
 
 create_virtualenvs() {
     local service user="$1"

--- a/services/api/config.toml
+++ b/services/api/config.toml
@@ -8,7 +8,7 @@ subscription = "home/sensors/#"
 status_subscription = "home/status/#"
 
 [sensors]
-known_ids = ["bme280", "scd40", "inmp441"]
+known_ids = ["bme280", "scd40", "sgp40", "inmp441"]
 stale_threshold_seconds = 120
 
 [auth]

--- a/services/sgp40/config.toml
+++ b/services/sgp40/config.toml
@@ -1,0 +1,20 @@
+# SGP40 service configuration.
+# Global broker and logging defaults are loaded from config/global.toml.
+
+[sensor]
+# I2C bus number. On Raspberry Pi, bus 1 is the standard 40-pin header bus.
+i2c_bus = 1
+
+# The SGP40 I2C address is factory-fixed at 0x59.
+i2c_address = 0x59
+
+# How often to publish to MQTT (seconds).
+# The sensor is sampled every 1 s internally to feed the Sensirion VOC
+# Algorithm; this value controls how often the latest index is published.
+publish_interval_seconds = 60
+
+[mqtt]
+topic = "home/sensors/air/sgp40"
+client_id = "sgp40-service"
+qos = 1
+retain = true

--- a/services/sgp40/main.py
+++ b/services/sgp40/main.py
@@ -1,0 +1,212 @@
+"""SGP40 VOC sensor service.
+
+Polling loop:
+  1. Call sensor.read() every ~1 s so the Sensirion VOC Algorithm can
+     maintain its internal baseline.
+  2. Every publish_interval_seconds (default 60 s), publish the latest
+     VOC Index to the configured MQTT topic.
+  3. On SIGTERM/SIGINT, complete the current 1-second sample, publish a
+     final reading if available, then shut down cleanly.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from common.config import load_config
+from common.i2c import I2CError
+from common.models import Diagnostics, Meta, SGP40Payload, SGP40Readings
+from common.mqtt import LWTConfig, MQTTClient, configure_logging
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from sensor import SGP40Sensor, _SAMPLE_INTERVAL_S
+
+logger = logging.getLogger("sgp40")
+
+_stop = threading.Event()
+
+
+def _handle_signal(signum: int, frame: object) -> None:
+    logger.info(
+        "Signal %d received — shutting down", signum, extra={"event": "service_shutdown"}
+    )
+    _stop.set()
+
+
+def _wait_for_connect(client: MQTTClient, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while not client.is_connected:
+        if time.monotonic() >= deadline:
+            return False
+        if _stop.is_set():
+            return False
+        _stop.wait(timeout=0.1)
+    return True
+
+
+def main() -> None:
+    configure_logging(level="INFO", fmt="text")
+
+    config_path = Path(__file__).parent / "config.toml"
+    try:
+        cfg = load_config(config_path)
+    except Exception as exc:
+        logger.critical("Failed to load config from %s: %s", config_path, exc)
+        sys.exit(1)
+
+    configure_logging(
+        level=cfg["logging"]["level"],
+        fmt=cfg["logging"]["format"],
+    )
+
+    logger.info("SGP40 service starting", extra={"event": "service_started"})
+    logger.info("Config loaded from %s", config_path, extra={"event": "config_loaded"})
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    broker = cfg["broker"]
+    mqtt_cfg = cfg["mqtt"]
+
+    status_topic = "home/status/sgp40"
+    client = MQTTClient(
+        client_id=mqtt_cfg["client_id"],
+        broker_host=broker["host"],
+        broker_port=broker["port"],
+        keepalive=broker["keepalive"],
+        lwt=LWTConfig(
+            topic=status_topic,
+            payload='{"status": "offline"}',
+            qos=1,
+            retain=True,
+        ),
+    )
+
+    try:
+        client.connect()
+    except Exception as exc:
+        logger.critical(
+            "Cannot reach MQTT broker at %s:%d: %s",
+            broker["host"],
+            broker["port"],
+            exc,
+        )
+        sys.exit(1)
+
+    client.loop_start()
+
+    if not _wait_for_connect(client):
+        logger.critical(
+            "Timed out waiting for MQTT connection to %s:%d",
+            broker["host"],
+            broker["port"],
+        )
+        client.loop_stop()
+        sys.exit(1)
+
+    sensor_cfg = cfg["sensor"]
+    sensor = SGP40Sensor(
+        bus=sensor_cfg.get("i2c_bus", 1),
+        address=sensor_cfg.get("i2c_address", 0x59),
+    )
+
+    try:
+        sensor.open()
+    except I2CError as exc:
+        logger.critical("Sensor init failed: %s", exc, extra={"event": "sensor_error"})
+        client.loop_stop()
+        sys.exit(1)
+
+    try:
+        client.publish(status_topic, '{"status": "online"}', qos=1, retain=True)
+        logger.info("Published online status", extra={"event": "status_online"})
+    except RuntimeError as exc:
+        logger.warning("Could not publish online status: %s", exc)
+
+    topic: str = mqtt_cfg["topic"]
+    qos: int = mqtt_cfg.get("qos", 1)
+    retain: bool = mqtt_cfg.get("retain", True)
+    publish_interval: float = float(sensor_cfg.get("publish_interval_seconds", 60))
+
+    service_start = time.monotonic()
+    read_failures = 0
+    last_voc_index: int | None = None
+
+    logger.info(
+        "Entering poll loop (sample_interval=%.0fs, publish_interval=%.0fs)",
+        _SAMPLE_INTERVAL_S,
+        publish_interval,
+        extra={"event": "poll_loop_start"},
+    )
+
+    next_publish = time.monotonic() + publish_interval
+
+    while not _stop.is_set():
+        # ---- 1-second sample ------------------------------------------------
+        cycle_start = time.monotonic()
+        try:
+            data = sensor.read()
+            last_voc_index = data["voc_index"]
+            logger.debug(
+                "VOC Index: %d",
+                last_voc_index,
+                extra={"event": "sensor_read"},
+            )
+        except I2CError as exc:
+            read_failures += 1
+            logger.warning(
+                "Read failed: %s (total failures: %d)",
+                exc,
+                read_failures,
+                extra={"event": "sensor_error"},
+            )
+
+        # ---- Publish on interval --------------------------------------------
+        now = time.monotonic()
+        if now >= next_publish and last_voc_index is not None:
+            logger.info(
+                "VOC Index: %d (failures: %d)",
+                last_voc_index,
+                read_failures,
+                extra={"event": "sensor_read"},
+            )
+            payload = SGP40Payload(
+                sensor_id="sgp40",
+                timestamp=datetime.now(tz=timezone.utc),
+                readings=SGP40Readings(voc_index=last_voc_index),
+                meta=Meta(sample_count=1, aggregation="latest"),
+                diagnostics=Diagnostics(
+                    uptime_seconds=now - service_start,
+                    read_failures=read_failures,
+                ),
+            )
+            try:
+                client.publish(topic, payload.model_dump_json(), qos=qos, retain=retain)
+            except RuntimeError as exc:
+                logger.error(
+                    "Publish failed: %s", exc, extra={"event": "mqtt_publish_error"}
+                )
+            next_publish = now + publish_interval
+
+        # ---- Sleep for the remainder of the 1-second sample interval --------
+        elapsed = time.monotonic() - cycle_start
+        remaining = _SAMPLE_INTERVAL_S - elapsed
+        if remaining > 0:
+            _stop.wait(timeout=remaining)
+
+    logger.info("Stopping poll loop", extra={"event": "service_shutdown"})
+    sensor.close()
+    client.loop_stop()
+    client.disconnect()
+    logger.info("SGP40 service stopped", extra={"event": "service_stopped"})
+
+
+if __name__ == "__main__":
+    main()

--- a/services/sgp40/requirements.txt
+++ b/services/sgp40/requirements.txt
@@ -1,0 +1,1 @@
+adafruit-circuitpython-sgp40

--- a/services/sgp40/sensor.py
+++ b/services/sgp40/sensor.py
@@ -1,0 +1,113 @@
+"""SGP40 VOC sensor driver — wraps adafruit-circuitpython-sgp40."""
+
+from __future__ import annotations
+
+import logging
+
+from common.i2c import I2CBase, I2CError
+
+logger = logging.getLogger(__name__)
+
+# Sensirion recommends calling measure_index() at ~1 s intervals.
+# The algorithm builds an internal baseline from the running history;
+# skipping cycles causes the baseline to drift and the index to become
+# less accurate.  The service main loop enforces this cadence.
+_SAMPLE_INTERVAL_S = 1.0
+
+
+class SGP40Sensor(I2CBase):
+    """Read the VOC Index from an SGP40 gas sensor over I2C.
+
+    The SGP40 measures volatile organic compounds (VOCs) and reports a
+    processed VOC Index on the Sensirion scale (1–500):
+
+      - 1–100  : cleaner than average indoor air
+      - 100    : typical indoor air (algorithm baseline)
+      - 100–200: mildly elevated VOCs
+      - 200–300: poor air quality (noticeable odours / contaminants)
+      - 300–500: very poor / hazardous
+
+    The Adafruit ``adafruit_sgp40.SGP40.measure_index()`` method runs the
+    Sensirion VOC Algorithm internally.  It should be called every
+    :data:`_SAMPLE_INTERVAL_S` seconds so the algorithm can maintain its
+    exponential moving average baseline.
+
+    Example::
+
+        sensor = SGP40Sensor(address=0x59)
+        sensor.open()
+        data = sensor.read()   # {"voc_index": 97}
+    """
+
+    _FIXED_ADDRESS = 0x59
+
+    def __init__(self, bus: int = 1, *, address: int = 0x59) -> None:
+        super().__init__(bus=bus, address=address)
+        self._sgp40 = None
+
+    # ------------------------------------------------------------------
+    # Hardware lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        """Explicitly initialise hardware.  Raises :class:`~common.i2c.I2CError` on failure."""
+        self._init_hardware()
+
+    def _init_hardware(self) -> None:
+        """Open the I2C bus and initialise the SGP40 device."""
+        try:
+            import board  # type: ignore[import-untyped]
+            import busio  # type: ignore[import-untyped]
+            import adafruit_sgp40  # type: ignore[import-untyped]
+
+            self._i2c = busio.I2C(board.SCL, board.SDA)
+            self._sgp40 = adafruit_sgp40.SGP40(self._i2c)
+            logger.info(
+                "SGP40 ready at I2C address 0x%02X (bus %d)",
+                self._address,
+                self._bus,
+                extra={"event": "i2c_bus_open"},
+            )
+        except I2CError:
+            raise
+        except Exception as exc:
+            if self._i2c is not None:
+                try:
+                    self._i2c.deinit()
+                except Exception:
+                    pass
+                self._i2c = None
+            self._sgp40 = None
+            raise I2CError(
+                f"Failed to initialise SGP40 at 0x{self._address:02X} on bus {self._bus}: {exc}"
+            ) from exc
+
+    def close(self) -> None:
+        """Release hardware resources."""
+        self._sgp40 = None
+        super().close()
+
+    # ------------------------------------------------------------------
+    # Sensor reading
+    # ------------------------------------------------------------------
+
+    def read(self) -> dict[str, int]:
+        """Return the current VOC Index.
+
+        Calls the Sensirion VOC Algorithm via the Adafruit library.
+        Should be called at ~1 s intervals for accurate baseline tracking.
+
+        Returns a dict with key ``voc_index`` (int, 0–500).
+
+        Raises :class:`~common.i2c.I2CError` on hardware failure.
+        """
+        if self._sgp40 is None:
+            self._init_hardware()
+
+        try:
+            index = self._sgp40.measure_index()
+            return {"voc_index": int(index)}
+        except I2CError:
+            raise
+        except Exception as exc:
+            raise I2CError(f"SGP40 read failed: {exc}") from exc

--- a/services/sgp40/sgp40.service
+++ b/services/sgp40/sgp40.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=Arkadia SGP40 VOC Sensor Service
+Documentation=https://github.com/malonge/Arkadia
+After=mosquitto.service
+Requires=mosquitto.service
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+
+# Change 'pi' to your actual username.
+User=pi
+Group=i2c
+
+# /etc/home-monitor.env must exist and define ARKADIA_ROOT.
+EnvironmentFile=/etc/home-monitor.env
+
+ExecStart=/bin/bash -c \
+  'exec "${ARKADIA_ROOT}/services/sgp40/.venv/bin/python" \
+        "${ARKADIA_ROOT}/services/sgp40/main.py"'
+
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+
+RuntimeDirectory=sgp40
+WorkingDirectory=/run/sgp40
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sgp40
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_sgp40.py
+++ b/tests/test_sgp40.py
@@ -1,0 +1,259 @@
+"""Unit tests for the SGP40 sensor service — no hardware required."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+SERVICE_DIR = Path(__file__).resolve().parent.parent / "services" / "sgp40"
+
+
+def _activate_service_path() -> None:
+    for other in ["services/bme280", "services/scd40"]:
+        p = str(Path(__file__).resolve().parent.parent / other)
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    if sys.path[:1] != [str(SERVICE_DIR)]:
+        try:
+            sys.path.remove(str(SERVICE_DIR))
+        except ValueError:
+            pass
+        sys.path.insert(0, str(SERVICE_DIR))
+    sys.modules.pop("sensor", None)
+
+
+# ---------------------------------------------------------------------------
+# Fake hardware helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_sgp40(voc_index: int = 97):
+    fake_device = MagicMock()
+    fake_device.measure_index.return_value = voc_index
+
+    fake_cls = MagicMock(return_value=fake_device)
+    fake_mod = types.ModuleType("adafruit_sgp40")
+    fake_mod.SGP40 = fake_cls
+    return fake_mod, fake_device
+
+
+def _make_fake_board_busio():
+    fake_board = types.ModuleType("board")
+    fake_board.SCL = MagicMock(name="SCL")
+    fake_board.SDA = MagicMock(name="SDA")
+    fake_i2c = MagicMock(name="I2CInstance")
+    fake_busio = types.ModuleType("busio")
+    fake_busio.I2C = MagicMock(return_value=fake_i2c)
+    return fake_board, fake_busio, fake_i2c
+
+
+def _inject_fakes(voc_index: int = 97):
+    fake_board, fake_busio, fake_i2c = _make_fake_board_busio()
+    fake_mod, fake_device = _make_fake_sgp40(voc_index)
+    sys.modules.update({
+        "board": fake_board,
+        "busio": fake_busio,
+        "adafruit_sgp40": fake_mod,
+    })
+    return fake_device, fake_busio, fake_i2c
+
+
+def _remove_fakes():
+    for mod in ("board", "busio", "adafruit_sgp40"):
+        sys.modules.pop(mod, None)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+class TestSGP40SensorConstruction:
+    def setup_method(self):
+        _activate_service_path()
+        _remove_fakes()
+
+    def test_fixed_address(self):
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        assert s._address == 0x59
+
+    def test_custom_bus(self):
+        from sensor import SGP40Sensor
+        s = SGP40Sensor(bus=0, address=0x59)
+        assert s._bus == 0
+
+    def test_no_hardware_on_construction(self):
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        assert s._sgp40 is None
+
+    def test_address_keyword_only(self):
+        from sensor import SGP40Sensor
+        with pytest.raises(TypeError):
+            SGP40Sensor(1, 0x59)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Hardware initialisation and reads
+# ---------------------------------------------------------------------------
+
+class TestSGP40SensorRead:
+    def setup_method(self):
+        _activate_service_path()
+        _remove_fakes()
+
+    def test_open_inits_hardware(self):
+        _, fake_busio, _ = _inject_fakes()
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        assert s._sgp40 is None
+        s.open()
+        assert s._sgp40 is not None
+        assert fake_busio.I2C.call_count == 1
+
+    def test_read_returns_voc_index_key(self):
+        _inject_fakes(voc_index=120)
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        result = s.read()
+        assert "voc_index" in result
+
+    def test_read_returns_correct_value(self):
+        _inject_fakes(voc_index=143)
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        result = s.read()
+        assert result["voc_index"] == 143
+
+    def test_read_value_is_int(self):
+        _inject_fakes(voc_index=97)
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        result = s.read()
+        assert isinstance(result["voc_index"], int)
+
+    def test_read_calls_measure_index(self):
+        fake_device, _, _ = _inject_fakes()
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        s.read()
+        fake_device.measure_index.assert_called()
+
+    def test_close_releases_device(self):
+        _inject_fakes()
+        from sensor import SGP40Sensor
+        s = SGP40Sensor()
+        s.open()
+        assert s._sgp40 is not None
+        s.close()
+        assert s._sgp40 is None
+
+    def test_read_hardware_error_raises_i2c_error(self):
+        fake_device, _, _ = _inject_fakes()
+        fake_device.measure_index.side_effect = RuntimeError("bus fault")
+        from sensor import SGP40Sensor
+        from common.i2c import I2CError
+        s = SGP40Sensor()
+        with pytest.raises(I2CError, match="SGP40 read failed"):
+            s.read()
+
+    def test_partial_init_failure_cleans_up_i2c(self):
+        fake_board, fake_busio, fake_i2c = _make_fake_board_busio()
+        fail_mod = types.ModuleType("adafruit_sgp40")
+        fail_mod.SGP40 = MagicMock(side_effect=RuntimeError("no device"))
+        sys.modules.update({
+            "board": fake_board,
+            "busio": fake_busio,
+            "adafruit_sgp40": fail_mod,
+        })
+        _activate_service_path()
+        from sensor import SGP40Sensor
+        from common.i2c import I2CError
+        s = SGP40Sensor()
+        with pytest.raises(I2CError):
+            s.open()
+        assert s._i2c is None
+        assert s._sgp40 is None
+
+
+# ---------------------------------------------------------------------------
+# Payload building
+# ---------------------------------------------------------------------------
+
+class TestSGP40PayloadBuilding:
+    def test_valid_payload(self):
+        from common.models import SGP40Payload, SGP40Readings, Meta
+
+        p = SGP40Payload(
+            sensor_id="sgp40",
+            timestamp=datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
+            readings=SGP40Readings(voc_index=97),
+            meta=Meta(sample_count=1, aggregation="latest"),
+        )
+        assert p.readings.voc_index == 97
+        assert p.sensor_id == "sgp40"
+
+    def test_json_roundtrip(self):
+        from common.models import SGP40Payload, SGP40Readings, Meta
+
+        p = SGP40Payload(
+            sensor_id="sgp40",
+            timestamp=datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
+            readings=SGP40Readings(voc_index=200),
+            meta=Meta(sample_count=1, aggregation="latest"),
+        )
+        d = json.loads(p.model_dump_json())
+        assert d["readings"]["voc_index"] == 200
+        assert d["schema_version"] == 1
+
+    def test_voc_index_below_zero_rejected(self):
+        from common.models import SGP40Readings
+        with pytest.raises(ValidationError):
+            SGP40Readings(voc_index=-1)
+
+    def test_voc_index_above_500_rejected(self):
+        from common.models import SGP40Readings
+        with pytest.raises(ValidationError):
+            SGP40Readings(voc_index=501)
+
+    def test_voc_index_boundary_values_accepted(self):
+        from common.models import SGP40Readings
+        assert SGP40Readings(voc_index=0).voc_index == 0
+        assert SGP40Readings(voc_index=500).voc_index == 500
+
+    def test_wrong_sensor_id(self):
+        from common.models import SGP40Payload, SGP40Readings, Meta
+        with pytest.raises(ValidationError):
+            SGP40Payload(
+                sensor_id="bme280",
+                timestamp=datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
+                readings=SGP40Readings(voc_index=100),
+                meta=Meta(sample_count=1, aggregation="latest"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestSGP40Config:
+    def test_config_loads(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["sensor"]["i2c_address"] == 0x59
+        assert cfg["sensor"]["publish_interval_seconds"] == 60
+        assert cfg["mqtt"]["topic"] == "home/sensors/air/sgp40"
+
+    def test_global_defaults_merged(self):
+        from common.config import load_config
+        cfg = load_config(SERVICE_DIR / "config.toml")
+        assert cfg["broker"]["host"] == "localhost"
+        assert cfg["broker"]["port"] == 1883

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -22,6 +22,7 @@
   import BarMeter         from './components/BarMeter.svelte';
   import EQVisualizer     from './components/EQVisualizer.svelte';
   import WaveformScope    from './components/WaveformScope.svelte';
+  import VocIndicator     from './components/VocIndicator.svelte';
 
   // ---------------------------------------------------------------------------
   // Settings gate
@@ -92,6 +93,7 @@
 
   let bme280  = $state(makeSensor('CLIMATE'));
   let scd40   = $state(makeSensor('AIR QUALITY'));
+  let sgp40   = $state(makeSensor('VOC'));
   let inmp441 = $state(makeSensor('AUDIO'));
 
   // Derived display values for BME280
@@ -111,6 +113,10 @@
   const co2Status     = $derived(statusFor(co2Ppm,    THRESHOLDS.co2_ppm));
   const scdTempStatus = $derived(statusFor(scdTempC,  THRESHOLDS.temperature_c));
   const scdHumStatus  = $derived(statusFor(scdHumPct, THRESHOLDS.humidity_pct));
+
+  // Derived display values for SGP40
+  const vocIndex  = $derived(sgp40.readings?.voc_index ?? null);
+  const vocStatus = $derived(statusFor(vocIndex, THRESHOLDS.voc_index));
 
   // ---------------------------------------------------------------------------
   // WebSocket audio stream
@@ -135,12 +141,13 @@
   let pollTimer       = null;
 
   async function poll() {
-    const [healthRes, sensorsRes, s1Res, s2Res, s3Res] = await Promise.allSettled([
+    const [healthRes, sensorsRes, s1Res, s2Res, s3Res, s4Res] = await Promise.allSettled([
       fetchHealth(),
       fetchSensors(),
       fetchSensorStatus('bme280'),
       fetchSensorStatus('scd40'),
       fetchSensorStatus('inmp441'),
+      fetchSensorStatus('sgp40'),
     ]);
 
     // Broker health
@@ -153,6 +160,7 @@
       const d = sensorsRes.value;
       if (d.bme280)  bme280.readings  = d.bme280.readings;
       if (d.scd40)   scd40.readings   = d.scd40.readings;
+      if (d.sgp40)   sgp40.readings   = d.sgp40.readings;
       if (d.inmp441) inmp441.readings = d.inmp441.readings;
     }
 
@@ -167,6 +175,7 @@
     applyStatus(s1Res, bme280);
     applyStatus(s2Res, scd40);
     applyStatus(s3Res, inmp441);
+    applyStatus(s4Res, sgp40);
 
     // Mark overall poll result
     const anyFailed = [healthRes, sensorsRes].some(r => r.status === 'rejected');
@@ -271,9 +280,9 @@
         </div>
       </SensorCard>
 
-      <!-- ── AIR QUALITY (SCD40) ─────────────────────────────────────── -->
+      <!-- ── AIR QUALITY (SCD40 + SGP40) ────────────────────────────── -->
       <SensorCard
-        title={scd40.title}
+        title="AIR QUALITY"
         sensorId="scd40"
         connectivity={scd40.connectivity}
         lastSeen={scd40.lastSeen}
@@ -324,8 +333,11 @@
             {/if}
           </div>
         {:else}
-          <p class="awaiting muted">AWAITING SENSOR DATA…</p>
+          <p class="awaiting muted">AWAITING CO₂ DATA…</p>
         {/if}
+
+        <!-- SGP40 VOC Index -->
+        <VocIndicator value={vocIndex} status={vocStatus} />
       </SensorCard>
 
       <!-- ── AUDIO (INMP441) ────────────────────────────────────────── -->

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -95,6 +95,13 @@ export const THRESHOLDS = {
     [-30,       -10,  'warn'  ],
     [-10,  Infinity,  'danger'],
   ],
+  /** SGP40 VOC Index (Sensirion scale, 1–500; 100 = typical indoor air) */
+  voc_index: [
+    [-Infinity, 101,  'good'  ],   // ≤ 100: cleaner than average
+    [101,       151,  'ok'    ],   // 101–150: good
+    [151,       251,  'warn'  ],   // 151–250: moderate
+    [251,  Infinity,  'danger'],   // > 250: poor / very poor
+  ],
 };
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/VocIndicator.svelte
+++ b/web/src/components/VocIndicator.svelte
@@ -1,0 +1,103 @@
+<script>
+  /**
+   * VocIndicator — single large indicator for the SGP40 VOC Index.
+   *
+   * The VOC Index (1–500, Sensirion scale) is displayed as a prominent number
+   * with a color-coded LED dot and a human-readable status label.
+   *
+   *   ≤ 100  : EXCELLENT  (green)
+   *   101–150: GOOD       (lime)
+   *   151–250: MODERATE   (amber)
+   *   > 250  : POOR+      (red)
+   *
+   * Props:
+   *   value   {number|null}  VOC Index, or null when no data
+   *   status  {string}       "good" | "ok" | "warn" | "danger" | "unknown"
+   */
+
+  const LABELS = {
+    good:    'EXCELLENT',
+    ok:      'GOOD',
+    warn:    'MODERATE',
+    danger:  'POOR',
+    unknown: 'NO DATA',
+  };
+
+  let { value = null, status = 'unknown' } = $props();
+
+  const label = $derived(LABELS[status] ?? 'NO DATA');
+</script>
+
+<div class="voc-indicator" aria-label="VOC Index: {value ?? 'no data'}, status: {label}">
+  <div class="voc-header">
+    <span class="label">VOC INDEX</span>
+    <span class="voc-label-tag label {status}">{label}</span>
+  </div>
+
+  <div class="voc-body">
+    <!-- Large colored indicator dot -->
+    <span class="voc-dot indicator indicator--{status}"></span>
+
+    <!-- Prominent number -->
+    <span class="voc-value reading--{status}">
+      {value != null ? value : '———'}
+    </span>
+
+    <!-- Scale hint -->
+    <span class="voc-scale dimmer">/ 500</span>
+  </div>
+</div>
+
+<style>
+  .voc-indicator {
+    display: flex;
+    flex-direction: column;
+    gap: var(--u2);
+    padding: var(--u3) 0;
+    border-top: 1px solid var(--dimmer);
+  }
+
+  .voc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .voc-label-tag {
+    letter-spacing: 0.06em;
+  }
+
+  /* Override label color to match status */
+  .voc-label-tag.good    { color: var(--status-good);    }
+  .voc-label-tag.ok      { color: var(--status-ok);      }
+  .voc-label-tag.warn    { color: var(--status-warn);    }
+  .voc-label-tag.danger  { color: var(--status-danger);  }
+  .voc-label-tag.unknown { color: var(--dim);            }
+
+  .voc-body {
+    display: flex;
+    align-items: center;
+    gap: var(--u4);
+  }
+
+  /* Larger LED dot than the inline ReadingRow indicator */
+  .voc-dot {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+  }
+
+  .voc-value {
+    font-family: var(--font-vt);
+    font-size: 52px;
+    line-height: 1;
+    transition: color 0.4s;
+  }
+
+  .voc-scale {
+    font-family: var(--font-pixel);
+    font-size: 7px;
+    align-self: flex-end;
+    padding-bottom: 6px;
+  }
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds full support for the Adafruit SGP40 VOC sensor — backend service, data model, API wiring, and a single-indicator frontend display.

---

### Sensor notes

You're correct that the SGP40 produces one output: the **VOC Index** (Sensirion scale, 1–500). Unlike a raw resistance reading, the index already has the Sensirion Gas Index Algorithm applied, which maintains an exponential moving average baseline over time.

**Important:** the algorithm expects to be called at approximately 1-second intervals. Calling it less frequently causes baseline drift. The service therefore loops at 1 Hz internally and publishes to MQTT every 60 seconds.

**Scale:**
| Range | Meaning |
|-------|---------|
| ≤ 100 | Cleaner than typical indoor air (excellent) |
| 101–150 | Good |
| 151–250 | Moderate — elevated VOCs |
| > 250 | Poor / very poor |

---

### Backend

**`services/sgp40/sensor.py`** — `SGP40Sensor(I2CBase)`: `open()` / `read()` / `close()` wrapping `adafruit_sgp40.SGP40.measure_index()`. Address fixed at `0x59`.

**`services/sgp40/main.py`** — 1 Hz inner loop feeds the VOC algorithm; publishes `SGP40Payload` to `home/sensors/air/sgp40` (QoS 1, retain) every 60 s. LWT at `home/status/sgp40`.

**`common/models.py`** — `SGP40Readings` (voc_index: int, 0–500), `SGP40Payload`, `SensorPayload` union updated.

**`services/api/config.toml`** — `sgp40` added to `known_ids`.

**`scripts/setup.sh` / `deploy.sh`** — `sgp40` added to service lists.

---

### Frontend

**`VocIndicator.svelte`** — large colored LED dot + 52 px VT323 number + status text label (EXCELLENT / GOOD / MODERATE / POOR). Color tracks the same `good/ok/warn/danger` system as every other reading. Displayed at the bottom of the Air Quality card.

**`THRESHOLDS.voc_index`** added to `api.js`.

---

### Deployment

```bash
# Pull and deploy on the Pi
git pull origin main
sudo bash scripts/deploy.sh
```

The virtualenv and `adafruit-circuitpython-sgp40` are installed automatically by `setup.sh`. If `setup.sh` has already been run, install manually:

```bash
python3 -m venv services/sgp40/.venv
services/sgp40/.venv/bin/pip install -e .
services/sgp40/.venv/bin/pip install -r services/sgp40/requirements.txt
```

---

**Testing**
- ✅ `ruff check .` — clean
- ✅ `pytest` — 283/283 passed (20 new SGP40 tests)
- ✅ `npm run build` — zero warnings, 63 kB JS / 13 kB CSS

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

