### PR TITLE
fix(sgp40): fix missing virtualenv crash; update all docs for SGP40

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arkadia
 
-Arkadia monitors home environment conditions — temperature, pressure, humidity, CO₂, and ambient sound — using sensors connected to a Raspberry Pi 5.
+Arkadia monitors home environment conditions — temperature, pressure, humidity, CO₂, volatile organic compounds (VOCs), and ambient sound — using sensors connected to a Raspberry Pi 5.  Readings are published to a local MQTT broker, exposed via a REST/WebSocket API, and displayed on a retro-styled web dashboard.
 
 Named after the base camp of the Skaikru in [The 100](https://en.wikipedia.org/wiki/The_100_(TV_series)).
 
@@ -8,15 +8,32 @@ Named after the base camp of the Skaikru in [The 100](https://en.wikipedia.org/w
 
 ## Architecture
 
-Sensor services publish JSON payloads to a local Mosquitto MQTT broker. An API service subscribes to all sensor topics, maintains the latest readings in memory, and exposes them over a REST API.
-
 ```
 bme280 ─┐
-scd40  ─┼──► Mosquitto :1883 ──► API :8000 ──► External consumers
+scd40  ─┤
+sgp40  ─┼──► Mosquitto :1883 ──► API :8000 ──► Web dashboard / external consumers
 audio  ─┘
+              (retained MQTT)    (REST + WebSocket)
 ```
 
-See [`docs/tech-design.md`](docs/tech-design.md) for the full technical design.
+Sensor services publish retained JSON payloads to a local Mosquitto broker.  The API service subscribes to all sensor topics, maintains the latest readings in memory, and exposes them over HTTP and a WebSocket endpoint for real-time audio streaming.
+
+See [`docs/tech-design.md`](docs/tech-design.md) for the full technical design and [`docs/dev-plan.md`](docs/dev-plan.md) for the implementation history.
+
+---
+
+## Sensors
+
+| Sensor  | Interface | I2C Address | Topic                         | Measurements                        |
+|---------|-----------|-------------|-------------------------------|-------------------------------------|
+| BME280  | I2C       | `0x76/0x77` | `home/sensors/climate/bme280` | Temperature, humidity, pressure     |
+| SCD40   | I2C       | `0x62`      | `home/sensors/air/scd40`      | CO₂, temperature, humidity          |
+| SGP40   | I2C       | `0x59`      | `home/sensors/air/sgp40`      | VOC Index (Sensirion scale 1–500)   |
+| INMP441 | I2S       | —           | `home/sensors/audio/inmp441`  | Ambient sound (RMS / dBFS)          |
+
+The audio service also publishes a real-time stream at `home/sensors/audio/inmp441/stream` (QoS 0, non-retained, 20 Hz) for the WebSocket visualizer.
+
+All sensors publish an online/offline status to `home/status/{sensor_id}` via MQTT Last Will and Testament.
 
 ---
 
@@ -25,274 +42,117 @@ See [`docs/tech-design.md`](docs/tech-design.md) for the full technical design.
 ```
 arkadia/
 ├── common/                    # Shared library (config, models, MQTT, I2C)
+│   ├── config.py              # TOML loader, global+local merge
+│   ├── models.py              # Pydantic payload models for all sensors
+│   ├── mqtt.py                # paho-mqtt wrapper, LWT, structured logging
+│   └── i2c.py                 # I2C base class
+│
 ├── services/
-│   ├── bme280/
-│   │   ├── sensor.py          # BME280 driver (wraps adafruit-circuitpython-bme280)
-│   │   ├── main.py            # Polling loop + MQTT publish
-│   │   ├── config.toml        # Sensor and MQTT settings
-│   │   ├── bme280.service     # systemd unit file
-│   │   └── requirements.txt
-│   ├── scd40/
-│   │   ├── sensor.py          # SCD40 driver (wraps adafruit-circuitpython-scd4x)
-│   │   ├── main.py            # Polling loop + MQTT publish
-│   │   ├── config.toml        # Sensor and MQTT settings
-│   │   ├── scd40.service      # systemd unit file
-│   │   └── requirements.txt
-│   ├── audio/                 # Ambient sound service (pending)
-│   └── api/                   # REST API service (pending)
+│   ├── bme280/                # Climate sensor (temperature, humidity, pressure)
+│   ├── scd40/                 # CO₂ sensor
+│   ├── sgp40/                 # VOC sensor
+│   ├── audio/                 # I2S microphone (summary + real-time stream)
+│   └── api/                   # FastAPI REST + WebSocket service
+│
+├── web/                       # Svelte + Vite web dashboard
+│   └── src/
+│       ├── App.svelte         # Three-panel dashboard with polling + WebSocket
+│       ├── api.js             # API client, thresholds, audio stream
+│       └── components/        # Header, SensorCard, ReadingRow, TemperatureGauge,
+│                              # BarMeter, VocIndicator, EQVisualizer, WaveformScope
+│
 ├── config/
 │   └── global.toml            # Shared broker and logging defaults
 ├── mosquitto/
-│   └── mosquitto.conf         # Broker configuration
+│   └── mosquitto.conf         # Broker: localhost-only, anonymous, persistence
 ├── scripts/
-│   ├── setup.sh               # First-time system setup
-│   └── deploy.sh              # Service deployment / restart (pending)
-├── tests/                     # Unit tests (no hardware required)
+│   ├── setup.sh               # First-time system setup (packages, venvs, I2C/I2S)
+│   └── deploy.sh              # Deploy / restart all services
+├── skills/
+│   └── pi-deployment.md       # SOP for deploying and debugging on the Pi
+├── tests/                     # Unit tests — no hardware required
 └── pyproject.toml
-```
-
----
-
-## Development Quick Start
-
-These steps are for running the unit tests on any machine (no hardware required).
-
-Pi OS Bookworm (and any modern Debian/Ubuntu) enforces [PEP 668](https://peps.python.org/pep-0668/) — you cannot install packages into the system Python directly. Always use a virtual environment.
-
-```bash
-# Create and activate a virtualenv
-python3 -m venv .venv
-source .venv/bin/activate
-
-# Install the common library in editable mode
-pip install -e .
-
-# Run the tests
-pip install pytest
-pytest
 ```
 
 ---
 
 ## Deploying on Raspberry Pi
 
-### 1. Enable I2C
+### First-time setup
 
 ```bash
-sudo raspi-config
-# → Interface Options → I2C → Enable
-# Reboot after enabling.
-```
-
-Or add the line directly and reboot:
-
-```bash
-echo "dtparam=i2c_arm=on" | sudo tee -a /boot/firmware/config.txt
-sudo reboot
-```
-
-Verify I2C is up and your sensor is visible:
-
-```bash
-sudo apt-get install -y i2c-tools
-i2cdetect -y 1
-```
-
-You should see `76` or `77` in the grid output:
-
-```
-     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
-00:                         -- -- -- -- -- -- -- -- --
-...
-70: -- -- -- -- -- -- 76 --
-```
-
-If your sensor appears at `77` (SDO pin pulled high), edit `services/bme280/config.toml` and change `i2c_address = 0x76` to `i2c_address = 0x77` before continuing.
-
-### 2. Install system packages
-
-```bash
+git clone https://github.com/malonge/Arkadia
+cd Arkadia
 sudo bash scripts/setup.sh
 ```
 
-This installs Mosquitto and applies `mosquitto/mosquitto.conf`.
+`setup.sh` handles everything in one pass:
+- Installs system packages (`mosquitto`, `python3-venv`, `i2c-tools`, `nodejs`, etc.)
+- Configures and starts Mosquitto
+- Enables I2C via `raspi-config`
+- Configures I2S for the INMP441 microphone in `/boot/firmware/config.txt`
+- Creates a Python virtualenv for each service and installs its dependencies
+- Scaffolds `/etc/home-monitor.env` with `ARKADIA_ROOT` and a placeholder `MONITOR_API_KEY`
 
-### 3. Create the environment file
-
-All services read `/etc/home-monitor.env` for the repository root path and any secrets.  Create it before enabling any service:
-
-```bash
-sudo tee /etc/home-monitor.env > /dev/null << EOF
-# Absolute path to the Arkadia repository on this machine.
-ARKADIA_ROOT=/home/$(whoami)/Projects/Arkadia
-EOF
-```
-
-Adjust the path to match where you cloned the repo.
-
-### 4. Set up the BME280 service virtualenv
+After setup, set a real API key:
 
 ```bash
-cd services/bme280
-
-# Create a virtualenv dedicated to this service
-python3 -m venv .venv
-
-# Install the common library from the repo
-.venv/bin/pip install -e ../..
-
-# Install the sensor driver and hardware abstraction layer
-.venv/bin/pip install -r requirements.txt
+sudo nano /etc/home-monitor.env
+# Set MONITOR_API_KEY to a strong random value, e.g.:
+# python3 -c "import secrets; print(secrets.token_hex(32))"
 ```
 
-### 5. Test the service manually before enabling systemd
+If the I2S lines were added to `/boot/firmware/config.txt`, reboot before continuing.
+
+### Deploy
 
 ```bash
-# Make sure Mosquitto is running
-sudo systemctl start mosquitto
-
-# Run the service in the foreground — you should see JSON log lines
-# and retained MQTT messages after ~35 s (5 samples × 0.5 s + 30 s sleep)
-.venv/bin/python main.py
+sudo bash scripts/deploy.sh
 ```
 
-In another terminal, subscribe to verify the payload arrives:
+Copies unit files, fixes `User=` to the actual username, enables all services, and starts them in dependency order (`mosquitto` → sensors → `api`).  Safe to re-run after any code or config change.
+
+### Verify all services are up
 
 ```bash
-mosquitto_sub -h 127.0.0.1 -t 'home/sensors/climate/bme280' -v
+systemctl status bme280 scd40 sgp40 audio api
+journalctl -u sgp40 -f          # follow logs for one service
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/#' -v    # watch all readings
+mosquitto_sub -h 127.0.0.1 -t 'home/status/#' -v     # watch connectivity
+i2cdetect -y 1                  # should show 0x59, 0x62, 0x76/0x77
 ```
 
-Press Ctrl-C to stop the service once you have confirmed it is working.
-
-### 6. Install and enable the systemd service
-
-```bash
-# Install the service file
-sudo cp services/bme280/bme280.service /etc/systemd/system/
-
-# Change the User= field in the installed copy to your actual username
-sudo sed -i "s/^User=pi$/User=$(whoami)/" /etc/systemd/system/bme280.service
-
-# Confirm it looks right
-grep "^User=" /etc/systemd/system/bme280.service
-
-# Reload systemd and enable
-sudo systemctl daemon-reload
-sudo systemctl enable bme280
-sudo systemctl start bme280
-```
-
-> **Note for Pi 5 / adafruit-blinka:** `lgpio` (the GPIO backend) creates
-> temporary notification files in the service's working directory.
-> `bme280.service` already sets `RuntimeDirectory=bme280` and
-> `WorkingDirectory=/run/bme280` to give it a writable location.  If you
-> ever need to re-apply this fix to an already-installed service file (e.g.
-> after installing from an older commit), use a drop-in override:
-> ```bash
-> sudo mkdir -p /etc/systemd/system/bme280.service.d
-> sudo tee /etc/systemd/system/bme280.service.d/workdir.conf > /dev/null << 'EOF'
-> [Service]
-> RuntimeDirectory=bme280
-> WorkingDirectory=/run/bme280
-> EOF
-> sudo systemctl daemon-reload
-> ```
-
-### 7. Verify
-
-```bash
-# Check service status
-sudo systemctl status bme280
-
-# Watch structured JSON logs
-journalctl -u bme280 -f
-
-# Watch the MQTT topic
-mosquitto_sub -h 127.0.0.1 -t 'home/sensors/climate/bme280' -v
-```
+For detailed per-service deployment steps and troubleshooting, see [`skills/pi-deployment.md`](skills/pi-deployment.md).
 
 ---
 
-## Sensors
+## Web Dashboard
 
-| Sensor  | Interface | Topic                         | Measurements                        | Status  |
-|---------|-----------|-------------------------------|-------------------------------------|---------|
-| BME280  | I2C       | `home/sensors/climate/bme280` | Temperature, humidity, pressure     | ✅ done |
-| SCD40   | I2C       | `home/sensors/air/scd40`      | CO₂, temperature, humidity          | ✅ done |
-| INMP441 | I2S       | `home/sensors/audio/inmp441`  | Ambient sound (RMS / dBFS)          | pending |
+The dashboard is a Svelte + Vite app served from the API at `http://<pi>:8000/` (after PR 12 merges; during development, run it separately on port 5173).
 
-### SCD40 deployment
-
-The SCD40 follows the same deployment steps as the BME280 (see above).
-Key differences:
-
-- **Fixed I2C address:** `0x62` — no SDO pin, no config needed.
-- **Measurement cycle:** The SCD40 produces a new reading every 5 seconds
-  internally.  `read()` blocks until `data_ready` is `True`; collecting 3
-  samples therefore takes ~15 seconds.
-- **Virtualenv setup:**
-  ```bash
-  cd services/scd40
-  python3 -m venv .venv
-  .venv/bin/pip install -e ../..
-  .venv/bin/pip install -r requirements.txt
-  ```
-- **Manual test:**
-  ```bash
-  .venv/bin/python main.py
-  # First reading appears after ~15 s (3 × 5 s cycles)
-  mosquitto_sub -h 127.0.0.1 -t 'home/sensors/air/scd40' -v
-  ```
-- **Systemd install:**
-  ```bash
-  sudo cp services/scd40/scd40.service /etc/systemd/system/
-  sudo sed -i "s/^User=pi$/User=$(whoami)/" /etc/systemd/system/scd40.service
-  sudo systemctl daemon-reload
-  sudo systemctl enable scd40
-  sudo systemctl start scd40
-  journalctl -u scd40 -f
-  ```
-
----
-
-## Mosquitto smoke test
-
-After running `setup.sh`, verify the broker with a publish/subscribe round-trip:
+**Development (SSH tunnel from your Mac):**
 
 ```bash
-# Terminal 1 — subscribe
-mosquitto_sub -h 127.0.0.1 -t 'test/#' -v
+# Mac terminal — forward both ports
+ssh -L 5173:localhost:5173 -L 8000:localhost:8000 micheldelving@<pi-ip>
 
-# Terminal 2 — publish
-mosquitto_pub -h 127.0.0.1 -t 'test/hello' -m 'world'
+# Pi terminal — start the dev server
+cd ~/Projects/Arkadia/web
+npm install       # first time only
+npm run dev
 ```
 
-Expected output in terminal 1:
+Open `http://localhost:5173` in your browser.  The first load shows a settings modal — enter your `MONITOR_API_KEY`.
 
-```
-test/hello world
-```
+**Panels:**
 
-Verify that connections from outside localhost are refused (replace `<pi-ip>` with the Pi's LAN address):
+| Panel | Sensor | Displays |
+|-------|--------|---------|
+| CLIMATE | BME280 | Temperature gauge (16 pixel blocks, color-coded) + humidity + pressure |
+| AIR QUALITY | SCD40 + SGP40 | CO₂ bar meter + temperature/humidity; VOC Index with color indicator |
+| AUDIO | INMP441 | 8-band EQ visualizer (canvas, peak-hold) + waveform oscilloscope + RMS level |
 
-```bash
-mosquitto_pub -h <pi-ip> -t 'test/hello' -m 'world'
-# Expected: Connection refused
-```
-
-View broker logs:
-
-```bash
-journalctl -u mosquitto -f
-```
-
----
-
-## Configuration
-
-- Global defaults: `config/global.toml`
-- Per-service overrides: `services/<name>/config.toml`
-- Paths and secrets: `/etc/home-monitor.env`
+The header shows a live clock, date, and hardcoded location coordinates.  All readings have LED color indicators (green → lime → amber → red) based on health thresholds.
 
 ---
 
@@ -300,12 +160,40 @@ journalctl -u mosquitto -f
 
 Base URL: `http://<pi-hostname>:8000`
 
-| Method | Path                          | Description                     |
-|--------|-------------------------------|---------------------------------|
-| GET    | `/health`                     | Broker connectivity and uptime  |
-| GET    | `/version`                    | Service version and git commit  |
-| GET    | `/sensors`                    | Latest readings from all sensors|
-| GET    | `/sensors/{sensor_id}`        | Latest reading for one sensor   |
-| GET    | `/sensors/{sensor_id}/status` | Staleness metadata              |
+All endpoints except `/health` require `X-API-Key: <key>` (set in `/etc/home-monitor.env`).
 
-All endpoints except `/health` require an `X-API-Key` header.
+| Method    | Path                          | Description                              |
+|-----------|-------------------------------|------------------------------------------|
+| GET       | `/health`                     | Broker connectivity and uptime (no auth) |
+| GET       | `/version`                    | Service version and git commit           |
+| GET       | `/sensors`                    | Latest readings from all sensors         |
+| GET       | `/sensors/{sensor_id}`        | Latest reading for one sensor (200/404/503) |
+| GET       | `/sensors/{sensor_id}/status` | Staleness + connectivity metadata        |
+| WebSocket | `/ws/audio/stream`            | Real-time `AudioStreamPayload` at ~20 Hz |
+
+WebSocket authentication: `?api_key=<key>` query parameter.
+
+---
+
+## Development Quick Start
+
+Run the unit tests on any machine — no hardware required.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+pip install pytest ruff
+pytest          # 283 tests, all pass without hardware
+ruff check .    # linting
+```
+
+---
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `config/global.toml` | Shared broker host/port and logging defaults |
+| `services/<name>/config.toml` | Per-service sensor settings and MQTT topic |
+| `/etc/home-monitor.env` | `ARKADIA_ROOT` path and `MONITOR_API_KEY` secret |

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -354,3 +354,5 @@ The `googlevoicehat-soundcard` ALSA driver used on Pi 5 / Bookworm requires **48
 | systemd hardening directives | PR 3, 4, 5, 6 — all `.service` files |
 | `event` field in structured logs | PR 1 — `common/mqtt.py` and logging setup |
 | Secrets via `EnvironmentFile` only | PR 7 — `setup.sh` scaffolds `/etc/home-monitor.env` |
+| SGP40 VOC Index sensor | SGP40 PR — `services/sgp40/`, `common/models.py`, API `known_ids`, web `VocIndicator` |
+| deploy.sh creates missing virtualenvs | SGP40 docs fix — `ensure_virtualenvs()` in `deploy.sh` |

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -1,8 +1,8 @@
 # Home Environment Monitor — Technical Design Document
 
-**Version:** 1.1  
+**Version:** 1.2  
 **Platform:** Raspberry Pi 5  
-**Last Updated:** May 2026
+**Last Updated:** July 2026
 
 ---
 
@@ -57,6 +57,7 @@ The REST API is the single external interface for all consumers, including:
 |------|------|------|
 | BME280 | I2C | Temperature, humidity, pressure |
 | SCD40 | I2C | CO₂ concentration |
+| SGP40 | I2C | VOC Index (Sensirion scale 1–500) |
 | INMP441 | I2S | Ambient sound level |
 
 **Host Platform:** Raspberry Pi 5  
@@ -70,12 +71,12 @@ The REST API is the single external interface for all consumers, including:
 ┌─────────────────────────────────────────────────────────┐
 │                     Raspberry Pi 5                      │
 │                                                         │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐              │
-│  │  bme280  │  │  scd40   │  │  audio   │              │
-│  │ service  │  │ service  │  │ service  │              │
-│  └────┬─────┘  └────┬─────┘  └────┬─────┘              │
-│       │              │              │                  │
-│       └──────────────┼──────────────┘                  │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────┐  │
+│  │  bme280  │  │  scd40   │  │  sgp40   │  │ audio  │  │
+│  │ service  │  │ service  │  │ service  │  │service │  │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘  └───┬────┘  │
+│       │              │              │             │      │
+│       └──────────────┼──────────────┘─────────────┘     │
 │                      │ MQTT publish                    │
 │                      ▼                                 │
 │             ┌─────────────────┐                       │
@@ -103,6 +104,7 @@ The REST API is the single external interface for all consumers, including:
 | `mosquitto` | MQTT broker | systemd |
 | `bme280` | Python service | systemd |
 | `scd40` | Python service | systemd |
+| `sgp40` | Python service | systemd |
 | `audio` | Python service | systemd |
 | `api` | FastAPI service | systemd |
 
@@ -132,6 +134,12 @@ home-monitor/
 │   │   ├── sensor.py
 │   │   ├── config.toml
 │   │   └── scd40.service
+│   │
+│   ├── sgp40/
+│   │   ├── main.py
+│   │   ├── sensor.py
+│   │   ├── config.toml
+│   │   └── sgp40.service
 │   │
 │   ├── audio/
 │   │   ├── main.py
@@ -226,6 +234,51 @@ Sensor services are synchronous and single-threaded.
 - Topic: `home/sensors/air/scd40`
 - Interval: 60 seconds
 - Aggregation: Median of 3 samples
+
+---
+
+## SGP40 Service
+
+**Responsibility:** Measure indoor air quality as a VOC (Volatile Organic
+Compound) Index.
+
+- Interface: I2C at address `0x59`
+- Library: `adafruit-circuitpython-sgp40`
+- Topic: `home/sensors/air/sgp40`
+- Publish interval: 60 seconds
+- Internal sample rate: 1 Hz (required by the Sensirion VOC Algorithm)
+
+### Polling Loop (SGP40-specific)
+
+The Sensirion VOC Algorithm embedded in the library expects to be called at
+approximately 1-second intervals.  Calling it less frequently causes the
+exponential moving average baseline to drift and degrades index accuracy.
+The service therefore uses a nested loop:
+
+```text
+initialize MQTT + sensor
+loop forever (outer — publish every 60 s):
+    loop forever (inner — sample every 1 s):
+        call measure_index() → VOC Index (1–500)
+        if 60 s elapsed:
+            build SGP40Payload
+            publish to MQTT (QoS 1, retain=true)
+            break inner loop
+        sleep(1 s)
+```
+
+### VOC Index Scale
+
+| Range | Air Quality | Dashboard Color |
+|-------|-------------|-----------------|
+| 1–100 | Excellent (cleaner than average) | Green |
+| 101–150 | Good | Lime |
+| 151–250 | Moderate | Amber |
+| > 250 | Poor / Very Poor | Red |
+
+100 is the algorithm's baseline — values rise when VOC sources (cooking,
+cleaning products, off-gassing, occupancy) are detected above the learned
+background level.
 
 ---
 
@@ -362,6 +415,7 @@ Examples:
 
 - `home/sensors/climate/bme280`
 - `home/sensors/air/scd40`
+- `home/sensors/air/sgp40`
 - `home/sensors/audio/inmp441`
 - `home/sensors/audio/inmp441/stream`
 
@@ -695,11 +749,17 @@ Key models:
 |------|------|
 | `Meta` | Standard aggregation metadata |
 | `StreamMeta` | Extends `Meta` with `window_function` for audio stream frames |
+| `BME280Readings` | Temperature, humidity, pressure |
+| `SCD40Readings` | CO₂ concentration, temperature, humidity |
+| `SGP40Readings` | VOC Index (Sensirion scale 1–500) |
 | `AudioReadings` | Summary audio readings (RMS, dBFS) |
 | `FftBins` | FFT frequency bins (frequencies + magnitudes) |
 | `EqBands` | Octave-band levels for equalizer display |
 | `AudioStreamReadings` | Complete real-time frame (waveform + FFT + EQ bands + RMS) |
-| `AudioPayload` | Typed envelope for the summary topic |
+| `BME280Payload` | Typed envelope for `bme280` readings |
+| `SCD40Payload` | Typed envelope for `scd40` readings |
+| `SGP40Payload` | Typed envelope for `sgp40` readings |
+| `AudioPayload` | Typed envelope for the audio summary topic |
 | `AudioStreamPayload` | Typed envelope for the real-time stream topic |
 
 ## `common/i2c.py`
@@ -938,7 +998,8 @@ A reverse proxy such as nginx can provide:
 |------|------|------|------|
 | `home/sensors/climate/bme280` | 1 | `true` | Climate measurements (temperature, humidity, pressure) |
 | `home/sensors/air/scd40` | 1 | `true` | CO₂ measurements |
+| `home/sensors/air/sgp40` | 1 | `true` | VOC Index (1–500, Sensirion scale) — 60 s interval |
 | `home/sensors/audio/inmp441` | 1 | `true` | Audio summary (RMS amplitude, dBFS level) — 5 s interval |
 | `home/sensors/audio/inmp441/stream` | 0 | `false` | Real-time audio frames (waveform, FFT bins, EQ bands) — 20 Hz |
-| `home/status/{sensor_id}` | 1 | `true` | Optional online/offline LWT status |
+| `home/status/{sensor_id}` | 1 | `true` | Online/offline LWT status for all sensor services |
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -60,6 +60,36 @@ preflight() {
 }
 
 # ---------------------------------------------------------------------------
+# Ensure each service has a virtualenv (creates one if missing).
+# This makes deploy.sh safe to run after a new service is added without
+# requiring a full setup.sh re-run.
+# ---------------------------------------------------------------------------
+
+ensure_virtualenvs() {
+    local service_user="$1"
+    local service
+
+    for service in "${ALL_ARKADIA_SERVICES[@]}"; do
+        local svc_dir="${REPO_ROOT}/services/${service}"
+        local venv_dir="${svc_dir}/.venv"
+        local req_file="${svc_dir}/requirements.txt"
+
+        [[ -d "${svc_dir}" ]] || continue
+
+        if [[ ! -d "${venv_dir}" ]]; then
+            info "Creating missing virtualenv for ${service}..."
+            python3 -m venv "${venv_dir}"
+            "${venv_dir}/bin/pip" install --quiet -e "${REPO_ROOT}"
+            if [[ -f "${req_file}" ]]; then
+                "${venv_dir}/bin/pip" install --quiet -r "${req_file}"
+            fi
+            chown -R "${service_user}:${service_user}" "${venv_dir}"
+            info "  ${service} virtualenv ready."
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
 # Install service unit files
 # ---------------------------------------------------------------------------
 
@@ -164,6 +194,7 @@ info "Repository root : ${REPO_ROOT}"
 info "Service user    : ${SERVICE_USER}"
 
 preflight
+ensure_virtualenvs "${SERVICE_USER}"
 install_units "${SERVICE_USER}"
 enable_services
 start_services

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -150,7 +150,7 @@ start_services() {
     fi
 
     # Sensor services can start in parallel.
-    info "Starting sensor services (bme280, scd40, audio)..."
+    info "Starting sensor services (bme280, scd40, sgp40, audio)..."
     local service
     for service in "${SENSOR_SERVICES[@]}"; do
         if [[ -f "${SYSTEMD_DIR}/${service}.service" ]]; then
@@ -181,7 +181,7 @@ print_status() {
     done
     info ""
     info "View logs with:  journalctl -u <service> -f"
-    info "Full status  :   systemctl status bme280 scd40 audio api"
+    info "Full status  :   systemctl status bme280 scd40 sgp40 audio api"
 }
 
 # ---------------------------------------------------------------------------

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -193,7 +193,7 @@ async def _lifespan(app: FastAPI):
             extra={"event": "mqtt_connect_error"},
         )
 
-    known_ids_raw = sensor_cfg.get("known_ids", ["bme280", "scd40", "inmp441"])
+    known_ids_raw = sensor_cfg.get("known_ids", ["bme280", "scd40", "sgp40", "inmp441"])
     app.state.store = store
     app.state.connectivity = connectivity
     app.state.broadcaster = broadcaster

--- a/skills/pi-deployment.md
+++ b/skills/pi-deployment.md
@@ -188,39 +188,70 @@ mqtt_publish         — Summary: rms=0.00xx dBFS=-5x.x (frames=100, failures=0)
 
 ---
 
+## SGP40 VOC sensor
+
+The SGP40 communicates over I2C at address `0x59`.  No kernel overlays or
+special configuration are required beyond I2C being enabled.
+
+### Expected log output when working
+
+```
+i2c_bus_open    — SGP40 ready at I2C address 0x59 (bus 1)
+status_online   — Published online status
+poll_loop_start — Entering poll loop (sample_interval=1s, publish_interval=60s)
+sensor_read     — VOC Index: 97 (failures: 0)
+```
+
+The VOC Index starts near 100 (algorithm baseline) and typically takes
+5–10 minutes to settle after startup as the Sensirion exponential moving
+average initialises.
+
+### Verify the sensor is publishing
+
+```bash
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/air/sgp40' -v
+```
+
+---
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `status=217/USER` | `User=pi` in service file | Edit unit file, change to `User=micheldelving`, `daemon-reload` |
+| `.venv/bin/python: No such file or directory` | Virtualenv never created | `python3 -m venv services/<name>/.venv && services/<name>/.venv/bin/pip install -e . && services/<name>/.venv/bin/pip install -r services/<name>/requirements.txt`; or re-run `sudo bash scripts/setup.sh` |
 | `file:///…/common does not appear to be a Python project` | `pip install -e ./common` | Use `pip install -e .` from repo root |
 | `No input device matching 'plughw:0,0'` | ALSA string passed to sounddevice | Use integer index from `python -m sounddevice` |
 | `ALSA error -22 Invalid argument` | softvol/PortAudio incompatibility | Use hardware device index (`device = 0`) |
 | `arecord -l` shows nothing | Missing dtoverlay or no reboot | Check `/boot/firmware/config.txt`, reboot |
 | Very low RMS, flat waveform | Gain not set | `amixer -D hw:0 sset 'Mic' 10dB` |
 | `Start request repeated too quickly` | Service hit restart rate-limit | `sudo systemctl reset-failed <name>` then `start` |
+| SGP40 VOC Index stuck at 100 | Algorithm still warming up | Normal — allow 5–10 min; index stabilises once baseline is learned |
 
 ---
 
 ## Useful verification commands
 
 ```bash
-# System
+# --- All services ---
+systemctl status bme280 scd40 sgp40 audio api     # quick overview
+journalctl -u <name> -n 50 --no-pager             # last 50 log lines
+journalctl -u <name> -f                           # follow live logs
+sudo systemctl reset-failed <name>                # clear restart rate-limit
+
+# --- MQTT ---
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/#' -v          # all sensor readings
+mosquitto_sub -h 127.0.0.1 -t 'home/status/#' -v           # online/offline status
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/air/sgp40' -v  # SGP40 VOC only
+mosquitto_sub -h 127.0.0.1 -t 'home/sensors/audio/#' -v    # audio topics
+
+# --- Audio hardware ---
 arecord -l                                        # list ALSA capture devices
 arecord -D hw:0,0 --dump-hw-params                # show hardware constraints
 services/audio/.venv/bin/python -m sounddevice    # list PortAudio devices
-
-# Service management
-systemctl status audio
-journalctl -u audio -n 50 --no-pager
-journalctl -u audio -f
-sudo systemctl reset-failed audio                 # clear restart rate-limit
-
-# MQTT
-mosquitto_sub -h 127.0.0.1 -t 'home/sensors/audio/#' -v    # both topics
-mosquitto_sub -h 127.0.0.1 -t 'home/sensors/#' -v          # all sensors
-
-# Gain
 amixer -D hw:0                                    # show current mixer controls
 amixer -D hw:0 sset 'Mic' 10dB                   # set capture gain
+
+# --- I2C (BME280, SCD40, SGP40) ---
+i2cdetect -y 1                                    # scan bus 1 — should show 0x59, 0x62, 0x76/0x77
 ```

--- a/tests/test_api_connectivity.py
+++ b/tests/test_api_connectivity.py
@@ -147,7 +147,7 @@ def _make_app(
     if connectivity is None:
         connectivity = ConnectivityStore()
     if known_ids is None:
-        known_ids = {"bme280", "scd40", "inmp441"}
+        known_ids = {"bme280", "scd40", "sgp40", "inmp441"}
 
     mock_mqtt = MagicMock()
     mock_mqtt.is_connected = True

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -19,7 +19,7 @@ from services.api.ws import AudioStreamBroadcaster
 # ---------------------------------------------------------------------------
 
 _API_KEY = "test-secret-key"
-_KNOWN_IDS = {"bme280", "scd40", "inmp441"}
+_KNOWN_IDS = {"bme280", "scd40", "sgp40", "inmp441"}
 _STALE_THRESHOLD = 120
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

### 1. Service crash: `.venv/bin/python: No such file or directory`

**Root cause:** `deploy.sh` copies unit files and restarts services, but has never created Python virtualenvs — that's `setup.sh`'s job. When a new service (SGP40) is added and `deploy.sh` is run without re-running `setup.sh`, the virtualenv doesn't exist and the service crashes immediately with exit code 127.

**Fix:** `deploy.sh` now calls `ensure_virtualenvs()` before starting any service. For each service whose `.venv` directory is absent, it creates the virtualenv, installs the `common` package, and installs `requirements.txt`. This makes `deploy.sh` safe to run after adding a new service without a full `setup.sh` re-run.

**Immediate fix on the Pi** (before merging this PR):
```bash
cd ~/Projects/Arkadia
python3 -m venv services/sgp40/.venv
services/sgp40/.venv/bin/pip install -e .
services/sgp40/.venv/bin/pip install -r services/sgp40/requirements.txt
sudo systemctl reset-failed sgp40
sudo systemctl start sgp40
```

---

### 2. Documentation gaps

**`README.md`** — complete rewrite:
- Summary updated: SGP40 and web dashboard added
- Architecture diagram: `sgp40` service, web dashboard, WebSocket notation
- Sensors table: SGP40 added; all sensors marked done; stream topic and LWT noted
- Repository structure: `sgp40/`, `web/`, `skills/` added; `(pending)` labels removed
- Deployment section: manual per-service virtualenv steps replaced with `setup.sh` + `deploy.sh` workflow; verify commands added
- Web dashboard: new section with SSH tunnel dev workflow, panel descriptions
- API table: WebSocket endpoint added
- Development quick start: updated test count; `ruff` added

**`docs/tech-design.md`** (v1.1 → v1.2, July 2026):
- Hardware table, architecture diagram, process inventory, repo structure: SGP40 added
- Service definitions: full SGP40 section (polling loop, VOC Index scale, design rationale)
- Models table: `SGP40Readings`, `SGP40Payload` added; fixed formatting
- MQTT topics appendix: `home/sensors/air/sgp40` added

**`docs/dev-plan.md`:**
- Reference table: SGP40 service and deploy.sh fix entries added

**`skills/pi-deployment.md`:**
- New `## SGP40 VOC sensor` section: expected log output, MQTT verify command
- Troubleshooting table: `.venv` missing row + SGP40 warmup row added
- Verification commands: expanded to cover all services, I2C scan, MQTT status topics

---

**Testing**
- ✅ `shellcheck scripts/deploy.sh scripts/setup.sh` — clean
- ✅ `ruff check .` — clean
- ✅ `pytest` — 283/283 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa785423-fc46-4629-8569-6255a7ab4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

